### PR TITLE
Implement TypeScript integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ scale.
   <tr>
     <td><a href="https://www.typescriptlang.org/">TypeScript</a></td>
     <td><a href="integrations/typescript">@holypack/integration-typescript</a></td>
-    <td align="center">Work in progress</td>
+    <td align="center">Completed</td>
   </tr>
   <tr>
     <td><a href="https://babeljs.io/">Babel</a></td>

--- a/e2e/integrations/typescript/holypack.config.mjs
+++ b/e2e/integrations/typescript/holypack.config.mjs
@@ -1,0 +1,20 @@
+import typescript from "@holypack/integration-typescript";
+import { defineConfig } from "holypack";
+
+const HOLYPACK_CONFIG = defineConfig({
+  integrations: [
+    typescript(),
+  ],
+  plugins: [
+    {
+      name: "test",
+      onContextReady: (ctx) =>
+      {
+        // TODO(ertgl): Write a test for the TypeScript E2E example, instead of logging it for visual inspection.
+        console.log(ctx.typescript);
+      },
+    },
+  ],
+});
+
+export default HOLYPACK_CONFIG;

--- a/e2e/integrations/typescript/package.json
+++ b/e2e/integrations/typescript/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@holypack/e2e-integration-typescript",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@holypack/core": "*",
+    "@holypack/integration-typescript": "*",
+    "holypack": "*"
+  }
+}

--- a/e2e/integrations/typescript/src/main.mjs
+++ b/e2e/integrations/typescript/src/main.mjs
@@ -1,0 +1,16 @@
+// TODO(ertgl): Convert the ESLint integration example to a test.
+
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { resolveContext } from "holypack";
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = dirname(__filename);
+
+const context = await resolveContext({
+  cwd: dirname(__dirname),
+});
+
+console.log(context);

--- a/e2e/integrations/typescript/tsconfig.json
+++ b/e2e/integrations/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.scope.src.json"
+    },
+    {
+      "path": "./tsconfig.scope.workspace.json"
+    }
+  ]
+}

--- a/e2e/integrations/typescript/tsconfig.scope.src.json
+++ b/e2e/integrations/typescript/tsconfig.scope.src.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@holypack/integration-typescript/presets/tsconfig.scope.src.json"
+}

--- a/e2e/integrations/typescript/tsconfig.scope.workspace.json
+++ b/e2e/integrations/typescript/tsconfig.scope.workspace.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@holypack/integration-typescript/presets/tsconfig.scope.workspace.json"
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -26,6 +26,7 @@
     "@holypack/core": "portal:../packages/core",
     "@holypack/e2e-integration-custom": "portal:./integrations/custom",
     "@holypack/e2e-integration-eslint": "portal:./integrations/eslint",
+    "@holypack/e2e-integration-typescript": "portal:./integrations/typescript",
     "@holypack/eslint-plugin": "portal:../external/eslint-plugin",
     "@holypack/integration-eslint": "portal:../integrations/eslint",
     "@holypack/integration-typescript": "portal:../integrations/typescript",

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -851,7 +851,7 @@ __metadata:
     eslint-plugin-import-x: "npm:^4.10.6"
     eslint-plugin-jsdoc: "npm:^50.6.10"
     eslint-plugin-n: "npm:^17.17.0"
-    eslint-plugin-perfectionist: "npm:^4.12.2"
+    eslint-plugin-perfectionist: "npm:^4.12.3"
     eslint-plugin-yml: "npm:^1.18.0"
     fast-glob: "npm:^3.3.3"
     globals: "npm:^16.0.0"
@@ -1823,16 +1823,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-perfectionist@npm:^4.12.2":
-  version: 4.12.2
-  resolution: "eslint-plugin-perfectionist@npm:4.12.2"
+"eslint-plugin-perfectionist@npm:^4.12.3":
+  version: 4.12.3
+  resolution: "eslint-plugin-perfectionist@npm:4.12.3"
   dependencies:
     "@typescript-eslint/types": "npm:^8.31.0"
     "@typescript-eslint/utils": "npm:^8.31.0"
     natural-orderby: "npm:^5.0.0"
   peerDependencies:
     eslint: ">=8.45.0"
-  checksum: 10c0/a89616bf6a69cb7817f32ac11d3e181c2a5e596507db7f4d27496c3d850cc53811293b4116eed3c86baf397866937ec8c67a57d8f61eb7903ede5b35b1a8ccf5
+  checksum: 10c0/c0fa2e79e575a8e2a1574c5404412d5e6d58c0151b5844a1db390e113e314b02d7572338e00eab9eec5f496d0f3153f9f94727c30684f7343023e3bc13e0f85c
   languageName: node
   linkType: hard
 

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -857,9 +857,14 @@ __metadata:
     globals: "npm:^16.0.0"
     typescript-eslint: "npm:^8.31.0"
   peerDependencies:
+    "@holypack/core": "*"
+    "@holypack/integration-typescript": "*"
     lodash.escaperegexp: "*"
     tapable: "*"
     typescript: "*"
+  peerDependenciesMeta:
+    "@holypack/integration-typescript":
+      optional: true
   languageName: node
   linkType: soft
 

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -802,6 +802,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@holypack/e2e-integration-typescript@workspace:integrations/typescript":
+  version: 0.0.0-use.local
+  resolution: "@holypack/e2e-integration-typescript@workspace:integrations/typescript"
+  dependencies:
+    "@holypack/core": "npm:*"
+    "@holypack/integration-typescript": "npm:*"
+    holypack: "npm:*"
+  languageName: unknown
+  linkType: soft
+
 "@holypack/eslint-plugin@portal:../external/eslint-plugin::locator=%40holypack%2F__e2e__%40workspace%3A.":
   version: 0.0.0-use.local
   resolution: "@holypack/eslint-plugin@portal:../external/eslint-plugin::locator=%40holypack%2F__e2e__%40workspace%3A."
@@ -858,6 +868,8 @@ __metadata:
   resolution: "@holypack/integration-typescript@portal:../integrations/typescript::locator=%40holypack%2F__e2e__%40workspace%3A."
   dependencies:
     typescript: "npm:^5.8.3"
+  peerDependencies:
+    "@holypack/core": "*"
   languageName: node
   linkType: soft
 

--- a/hack/scripts/update-package-exports.mjs
+++ b/hack/scripts/update-package-exports.mjs
@@ -250,6 +250,7 @@ async function generatePackageExports(
     default: "./src/*.ts",
     /* eslint-enable perfectionist/sort-objects */
   };
+
   packageExports["./*.mjs"] = {
     /* eslint-disable perfectionist/sort-objects */
     types: "./dist/types/*.d.ts",

--- a/hack/scripts/update-package-exports.mjs
+++ b/hack/scripts/update-package-exports.mjs
@@ -7,7 +7,8 @@ import {
 import { createRequire } from "node:module";
 import {
   dirname,
-  sep as pathSeparator,
+  join as joinPaths,
+  parse as parsePath,
   relative,
 } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -47,17 +48,83 @@ async function generatePackageExports(
 
   const direntIterator = iterateDirentsRecursively(srcDirPath);
 
+  /**
+   * @type {Map<string, Set<string>>}
+   */
+  const seenExtensionsByParentPath = new Map();
+
   for await (const dirent of direntIterator)
   {
     if (!dirent.isDirectory())
     {
+      let seenExtensions = seenExtensionsByParentPath.get(
+        dirent.parentPath,
+      );
+
+      if (seenExtensions == null)
+      {
+        seenExtensions = new Set();
+        seenExtensionsByParentPath.set(
+          dirent.parentPath,
+          seenExtensions,
+        );
+      }
+
+      const direntPathInfo = parsePath(
+        joinPaths(
+          dirent.parentPath,
+          dirent.name,
+        ),
+      );
+
+      if (!direntPathInfo.ext)
+      {
+        continue;
+      }
+
+      seenExtensions.add(direntPathInfo.ext);
+
       continue;
     }
 
-    const direntPath = `${dirent.parentPath}${pathSeparator}${dirent.name}`;
+    const direntPath = joinPaths(
+      dirent.parentPath,
+      dirent.name,
+    );
+
     const direntSrcRelativePath = relative(
       srcDirPath,
       direntPath,
+    );
+
+    let seenExtensions = seenExtensionsByParentPath.get(
+      direntPath,
+    );
+
+    if (seenExtensions == null)
+    {
+      seenExtensions = new Set();
+    }
+    else
+    {
+      seenExtensionsByParentPath.delete(direntPath);
+    }
+
+    const seenCJS = seenExtensions.has(".cjs");
+    const seenCTS = seenExtensions.has(".cts");
+    const seenJS = seenExtensions.has(".js");
+    const seenJSON = seenExtensions.has(".json");
+    const seenMJS = seenExtensions.has(".mjs");
+    const seenMTS = seenExtensions.has(".mts");
+    const seenTS = seenExtensions.has(".ts");
+
+    const seenAnyJS = (
+      seenCJS
+      || seenCTS
+      || seenJS
+      || seenMJS
+      || seenMTS
+      || seenTS
     );
 
     const importPathPrefix = `./${direntSrcRelativePath}`;
@@ -80,57 +147,74 @@ async function generatePackageExports(
       /* eslint-enable perfectionist/sort-objects */
     };
 
-    packageExports[`${importPathPrefix}/*.d.ts`] = {
+    if (seenAnyJS)
+    {
+      packageExports[`${importPathPrefix}/*.d.ts`] = {
       /* eslint-disable perfectionist/sort-objects */
-      types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
-      default: `./src/${direntSrcRelativePath}/*.ts`,
+        types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
+        default: `./src/${direntSrcRelativePath}/*.ts`,
       /* eslint-enable perfectionist/sort-objects */
-    };
+      };
+    }
 
-    packageExports[`${importPathPrefix}/*.cjs`] = {
+    if (seenAnyJS)
+    {
+      packageExports[`${importPathPrefix}/*.cjs`] = {
       /* eslint-disable perfectionist/sort-objects */
-      types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
-      import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
-      require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
-      default: `./src/${direntSrcRelativePath}/*.ts`,
+        types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
+        import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
+        require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
+        default: `./src/${direntSrcRelativePath}/*.ts`,
       /* eslint-enable perfectionist/sort-objects */
-    };
+      };
+    }
 
-    packageExports[`${importPathPrefix}/*.js`] = {
+    if (seenJSON)
+    {
+      packageExports[`${importPathPrefix}/*.json`] = {
       /* eslint-disable perfectionist/sort-objects */
-      types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
-      import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
-      require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
-      default: `./src/${direntSrcRelativePath}/*.ts`,
+        import: `./dist/esm/${direntSrcRelativePath}/*.json`,
+        require: `./dist/cjs/${direntSrcRelativePath}/*.json`,
+        default: `./src/${direntSrcRelativePath}/*.json`,
       /* eslint-enable perfectionist/sort-objects */
-    };
+      };
+    }
 
-    packageExports[`${importPathPrefix}/*.mjs`] = {
+    if (seenAnyJS)
+    {
+      packageExports[`${importPathPrefix}/*.js`] = {
       /* eslint-disable perfectionist/sort-objects */
-      types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
-      import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
-      require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
-      default: `./src/${direntSrcRelativePath}/*.ts`,
+        types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
+        import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
+        require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
+        default: `./src/${direntSrcRelativePath}/*.ts`,
       /* eslint-enable perfectionist/sort-objects */
-    };
+      };
+    }
 
-    packageExports[`${importPathPrefix}/*.ts`] = {
+    if (seenAnyJS)
+    {
+      packageExports[`${importPathPrefix}/*.mjs`] = {
       /* eslint-disable perfectionist/sort-objects */
-      types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
-      import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
-      require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
-      default: `./src/${direntSrcRelativePath}/*.ts`,
+        types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
+        import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
+        require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
+        default: `./src/${direntSrcRelativePath}/*.ts`,
       /* eslint-enable perfectionist/sort-objects */
-    };
+      };
+    }
 
-    packageExports[`${importPathPrefix}/*/`] = {
+    if (seenAnyJS)
+    {
+      packageExports[`${importPathPrefix}/*.ts`] = {
       /* eslint-disable perfectionist/sort-objects */
-      types: `./dist/types/${direntSrcRelativePath}/*/index.d.ts`,
-      import: `./dist/esm/*/${direntSrcRelativePath}/index.mjs`,
-      require: `./dist/cjs/${direntSrcRelativePath}/*/index.cjs`,
-      default: `./src/*/${direntSrcRelativePath}/index.ts`,
+        types: `./dist/types/${direntSrcRelativePath}/*.d.ts`,
+        import: `./dist/esm/${direntSrcRelativePath}/*.mjs`,
+        require: `./dist/cjs/${direntSrcRelativePath}/*.cjs`,
+        default: `./src/${direntSrcRelativePath}/*.ts`,
       /* eslint-enable perfectionist/sort-objects */
-    };
+      };
+    }
 
     packageExports[`${importPathPrefix}/*`] = {
       /* eslint-disable perfectionist/sort-objects */
@@ -229,7 +313,12 @@ async function* iterateDirentsRecursively(
   {
     if (dirent.isDirectory())
     {
-      yield* iterateDirentsRecursively(`${path}${pathSeparator}${dirent.name}`);
+      yield* iterateDirentsRecursively(
+        joinPaths(
+          path,
+          dirent.name,
+        ),
+      );
       deferredDirents.push(dirent);
     }
     else if (dirent.isFile())

--- a/holypack.config.mjs
+++ b/holypack.config.mjs
@@ -1,8 +1,10 @@
 import eslint from "@holypack/integration-eslint";
+import typescript from "@holypack/integration-typescript";
 import { defineConfig } from "holypack";
 
 const HOLYPACK_CONFIG = defineConfig({
   integrations: [
+    typescript(),
     eslint(),
   ],
 });

--- a/integrations/babel/package.json
+++ b/integrations/babel/package.json
@@ -2,8 +2,8 @@
   "name": "@holypack/integration-babel",
   "scripts": {
     "babel:build": "cd $INIT_CWD && yarn babel:build::cjs && yarn babel:build::esm",
-    "babel:build::cjs": "cd $INIT_CWD && yarn cmd:babel src --config-file ./babel.config.cjs.mjs --extensions '.cjs,.cts,.js,.mjs,.mts,.ts' --ignore '**/*.d.ts' --out-dir ./dist/cjs --out-file-extension '.cjs'",
-    "babel:build::esm": "cd $INIT_CWD && yarn cmd:babel src --config-file ./babel.config.esm.mjs --extensions '.cjs,.cts,.js,.mjs,.mts,.ts' --ignore '**/*.d.ts' --out-dir ./dist/esm --out-file-extension '.mjs'",
+    "babel:build::cjs": "cd $INIT_CWD && yarn cmd:babel src --config-file ./babel.config.cjs.mjs --copy-files --extensions '.cjs,.cts,.js,.mjs,.mts,.ts' --ignore '**/*.d.ts' --out-dir ./dist/cjs --out-file-extension '.cjs'",
+    "babel:build::esm": "cd $INIT_CWD && yarn cmd:babel src --config-file ./babel.config.esm.mjs --copy-files --extensions '.cjs,.cts,.js,.mjs,.mts,.ts' --ignore '**/*.d.ts' --out-dir ./dist/esm --out-file-extension '.mjs'",
     "build": "yarn clean && yarn babel:build::cjs && yarn babel:build::esm && yarn tsc:build::types && yarn hack:update-package-exports",
     "clean": "rm -fr dist",
     "cmd:babel": "cd $INIT_CWD && babel"

--- a/integrations/eslint/README.md
+++ b/integrations/eslint/README.md
@@ -1,8 +1,0 @@
-# @holypack/integration-eslint
-
-## Known Issues
-
-- Use of `eslint-plugin-perfectionist` may cause performance issues in large
-  projects. It can be disabled by setting `perfectionist: false` in the
-  integration options. (For instance, linting holypack with `perfectionist`
-  enabled takes ~3 minutes, while it takes ~30 seconds with it disabled.)

--- a/integrations/eslint/package.json
+++ b/integrations/eslint/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-import-x": "^4.10.6",
     "eslint-plugin-jsdoc": "^50.6.10",
     "eslint-plugin-n": "^17.17.0",
-    "eslint-plugin-perfectionist": "^4.12.2",
+    "eslint-plugin-perfectionist": "^4.12.3",
     "eslint-plugin-yml": "^1.18.0",
     "fast-glob": "^3.3.3",
     "globals": "^16.0.0",

--- a/integrations/eslint/package.json
+++ b/integrations/eslint/package.json
@@ -11,11 +11,6 @@
     "eslint:lint": "cd $PROJECT_CWD && yarn cmd:eslint",
     "eslint:lint::fix": "cd $PROJECT_CWD && yarn cmd:eslint --fix"
   },
-  "peerDependencies": {
-    "lodash.escaperegexp": "*",
-    "tapable": "*",
-    "typescript": "*"
-  },
   "dependencies": {
     "@cspell/dict-bash": "^4.2.0",
     "@cspell/dict-css": "^4.0.17",
@@ -49,11 +44,25 @@
     "typescript-eslint": "^8.31.0"
   },
   "devDependencies": {
+    "@holypack/core": "workspace:*",
     "@holypack/integration-babel": "workspace:*",
+    "@holypack/integration-typescript": "workspace:*",
     "@types/lodash.escaperegexp": "^4",
     "lodash.escaperegexp": "^4.1.2",
     "tapable": "^2.2.1",
     "typescript": "^5.8.3"
+  },
+  "peerDependencies": {
+    "@holypack/core": "*",
+    "@holypack/integration-typescript": "*",
+    "lodash.escaperegexp": "*",
+    "tapable": "*",
+    "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "@holypack/integration-typescript": {
+      "optional": true
+    }
   },
   "files": [
     "./dist/",

--- a/integrations/eslint/package.json
+++ b/integrations/eslint/package.json
@@ -112,12 +112,6 @@
       "require": "./dist/cjs/constants/glob-patterns/*.cjs",
       "default": "./src/constants/glob-patterns/*.ts"
     },
-    "./constants/glob-patterns/*/": {
-      "types": "./dist/types/constants/glob-patterns/*/index.d.ts",
-      "import": "./dist/esm/*/constants/glob-patterns/index.mjs",
-      "require": "./dist/cjs/constants/glob-patterns/*/index.cjs",
-      "default": "./src/*/constants/glob-patterns/index.ts"
-    },
     "./constants/glob-patterns/*": {
       "types": "./dist/types/constants/glob-patterns/*",
       "import": "./dist/esm/constants/glob-patterns/*",
@@ -163,12 +157,6 @@
       "import": "./dist/esm/integration/module-augmentation/*.mjs",
       "require": "./dist/cjs/integration/module-augmentation/*.cjs",
       "default": "./src/integration/module-augmentation/*.ts"
-    },
-    "./integration/module-augmentation/*/": {
-      "types": "./dist/types/integration/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/integration/module-augmentation/index.mjs",
-      "require": "./dist/cjs/integration/module-augmentation/*/index.cjs",
-      "default": "./src/*/integration/module-augmentation/index.ts"
     },
     "./integration/module-augmentation/*": {
       "types": "./dist/types/integration/module-augmentation/*",
@@ -216,12 +204,6 @@
       "require": "./dist/cjs/plugins/cspell/module-augmentation/*.cjs",
       "default": "./src/plugins/cspell/module-augmentation/*.ts"
     },
-    "./plugins/cspell/module-augmentation/*/": {
-      "types": "./dist/types/plugins/cspell/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/cspell/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/cspell/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/cspell/module-augmentation/index.ts"
-    },
     "./plugins/cspell/module-augmentation/*": {
       "types": "./dist/types/plugins/cspell/module-augmentation/*",
       "import": "./dist/esm/plugins/cspell/module-augmentation/*",
@@ -267,12 +249,6 @@
       "import": "./dist/esm/plugins/eslint/js/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/eslint/js/module-augmentation/*.cjs",
       "default": "./src/plugins/eslint/js/module-augmentation/*.ts"
-    },
-    "./plugins/eslint/js/module-augmentation/*/": {
-      "types": "./dist/types/plugins/eslint/js/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/js/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/js/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/eslint/js/module-augmentation/index.ts"
     },
     "./plugins/eslint/js/module-augmentation/*": {
       "types": "./dist/types/plugins/eslint/js/module-augmentation/*",
@@ -320,12 +296,6 @@
       "require": "./dist/cjs/plugins/eslint/json/module-augmentation/*.cjs",
       "default": "./src/plugins/eslint/json/module-augmentation/*.ts"
     },
-    "./plugins/eslint/json/module-augmentation/*/": {
-      "types": "./dist/types/plugins/eslint/json/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/json/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/json/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/eslint/json/module-augmentation/index.ts"
-    },
     "./plugins/eslint/json/module-augmentation/*": {
       "types": "./dist/types/plugins/eslint/json/module-augmentation/*",
       "import": "./dist/esm/plugins/eslint/json/module-augmentation/*",
@@ -371,12 +341,6 @@
       "import": "./dist/esm/plugins/eslint/markdown/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/eslint/markdown/module-augmentation/*.cjs",
       "default": "./src/plugins/eslint/markdown/module-augmentation/*.ts"
-    },
-    "./plugins/eslint/markdown/module-augmentation/*/": {
-      "types": "./dist/types/plugins/eslint/markdown/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/markdown/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/markdown/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/eslint/markdown/module-augmentation/index.ts"
     },
     "./plugins/eslint/markdown/module-augmentation/*": {
       "types": "./dist/types/plugins/eslint/markdown/module-augmentation/*",
@@ -424,12 +388,6 @@
       "require": "./dist/cjs/plugins/eslint/js/*.cjs",
       "default": "./src/plugins/eslint/js/*.ts"
     },
-    "./plugins/eslint/js/*/": {
-      "types": "./dist/types/plugins/eslint/js/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/js/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/js/*/index.cjs",
-      "default": "./src/*/plugins/eslint/js/index.ts"
-    },
     "./plugins/eslint/js/*": {
       "types": "./dist/types/plugins/eslint/js/*",
       "import": "./dist/esm/plugins/eslint/js/*",
@@ -475,12 +433,6 @@
       "import": "./dist/esm/plugins/eslint/json/*.mjs",
       "require": "./dist/cjs/plugins/eslint/json/*.cjs",
       "default": "./src/plugins/eslint/json/*.ts"
-    },
-    "./plugins/eslint/json/*/": {
-      "types": "./dist/types/plugins/eslint/json/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/json/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/json/*/index.cjs",
-      "default": "./src/*/plugins/eslint/json/index.ts"
     },
     "./plugins/eslint/json/*": {
       "types": "./dist/types/plugins/eslint/json/*",
@@ -528,12 +480,6 @@
       "require": "./dist/cjs/plugins/eslint/markdown/*.cjs",
       "default": "./src/plugins/eslint/markdown/*.ts"
     },
-    "./plugins/eslint/markdown/*/": {
-      "types": "./dist/types/plugins/eslint/markdown/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/markdown/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/markdown/*/index.cjs",
-      "default": "./src/*/plugins/eslint/markdown/index.ts"
-    },
     "./plugins/eslint/markdown/*": {
       "types": "./dist/types/plugins/eslint/markdown/*",
       "import": "./dist/esm/plugins/eslint/markdown/*",
@@ -579,12 +525,6 @@
       "import": "./dist/esm/plugins/globals/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/globals/module-augmentation/*.cjs",
       "default": "./src/plugins/globals/module-augmentation/*.ts"
-    },
-    "./plugins/globals/module-augmentation/*/": {
-      "types": "./dist/types/plugins/globals/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/globals/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/globals/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/globals/module-augmentation/index.ts"
     },
     "./plugins/globals/module-augmentation/*": {
       "types": "./dist/types/plugins/globals/module-augmentation/*",
@@ -632,12 +572,6 @@
       "require": "./dist/cjs/plugins/ignores/module-augmentation/*.cjs",
       "default": "./src/plugins/ignores/module-augmentation/*.ts"
     },
-    "./plugins/ignores/module-augmentation/*/": {
-      "types": "./dist/types/plugins/ignores/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/ignores/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/ignores/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/ignores/module-augmentation/index.ts"
-    },
     "./plugins/ignores/module-augmentation/*": {
       "types": "./dist/types/plugins/ignores/module-augmentation/*",
       "import": "./dist/esm/plugins/ignores/module-augmentation/*",
@@ -683,12 +617,6 @@
       "import": "./dist/esm/plugins/import-x/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/import-x/module-augmentation/*.cjs",
       "default": "./src/plugins/import-x/module-augmentation/*.ts"
-    },
-    "./plugins/import-x/module-augmentation/*/": {
-      "types": "./dist/types/plugins/import-x/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/import-x/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/import-x/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/import-x/module-augmentation/index.ts"
     },
     "./plugins/import-x/module-augmentation/*": {
       "types": "./dist/types/plugins/import-x/module-augmentation/*",
@@ -736,12 +664,6 @@
       "require": "./dist/cjs/plugins/jsdoc/module-augmentation/*.cjs",
       "default": "./src/plugins/jsdoc/module-augmentation/*.ts"
     },
-    "./plugins/jsdoc/module-augmentation/*/": {
-      "types": "./dist/types/plugins/jsdoc/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/jsdoc/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/jsdoc/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/jsdoc/module-augmentation/index.ts"
-    },
     "./plugins/jsdoc/module-augmentation/*": {
       "types": "./dist/types/plugins/jsdoc/module-augmentation/*",
       "import": "./dist/esm/plugins/jsdoc/module-augmentation/*",
@@ -787,12 +709,6 @@
       "import": "./dist/esm/plugins/n/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/n/module-augmentation/*.cjs",
       "default": "./src/plugins/n/module-augmentation/*.ts"
-    },
-    "./plugins/n/module-augmentation/*/": {
-      "types": "./dist/types/plugins/n/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/n/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/n/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/n/module-augmentation/index.ts"
     },
     "./plugins/n/module-augmentation/*": {
       "types": "./dist/types/plugins/n/module-augmentation/*",
@@ -840,12 +756,6 @@
       "require": "./dist/cjs/plugins/perfectionist/module-augmentation/*.cjs",
       "default": "./src/plugins/perfectionist/module-augmentation/*.ts"
     },
-    "./plugins/perfectionist/module-augmentation/*/": {
-      "types": "./dist/types/plugins/perfectionist/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/perfectionist/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/perfectionist/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/perfectionist/module-augmentation/index.ts"
-    },
     "./plugins/perfectionist/module-augmentation/*": {
       "types": "./dist/types/plugins/perfectionist/module-augmentation/*",
       "import": "./dist/esm/plugins/perfectionist/module-augmentation/*",
@@ -891,12 +801,6 @@
       "import": "./dist/esm/plugins/stylistic/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/stylistic/module-augmentation/*.cjs",
       "default": "./src/plugins/stylistic/module-augmentation/*.ts"
-    },
-    "./plugins/stylistic/module-augmentation/*/": {
-      "types": "./dist/types/plugins/stylistic/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/stylistic/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/stylistic/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/stylistic/module-augmentation/index.ts"
     },
     "./plugins/stylistic/module-augmentation/*": {
       "types": "./dist/types/plugins/stylistic/module-augmentation/*",
@@ -944,12 +848,6 @@
       "require": "./dist/cjs/plugins/typescript/module-augmentation/*.cjs",
       "default": "./src/plugins/typescript/module-augmentation/*.ts"
     },
-    "./plugins/typescript/module-augmentation/*/": {
-      "types": "./dist/types/plugins/typescript/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/typescript/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/typescript/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/typescript/module-augmentation/index.ts"
-    },
     "./plugins/typescript/module-augmentation/*": {
       "types": "./dist/types/plugins/typescript/module-augmentation/*",
       "import": "./dist/esm/plugins/typescript/module-augmentation/*",
@@ -995,12 +893,6 @@
       "import": "./dist/esm/plugins/yml/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/yml/module-augmentation/*.cjs",
       "default": "./src/plugins/yml/module-augmentation/*.ts"
-    },
-    "./plugins/yml/module-augmentation/*/": {
-      "types": "./dist/types/plugins/yml/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/yml/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/yml/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/yml/module-augmentation/index.ts"
     },
     "./plugins/yml/module-augmentation/*": {
       "types": "./dist/types/plugins/yml/module-augmentation/*",
@@ -1048,12 +940,6 @@
       "require": "./dist/cjs/plugins/cspell/*.cjs",
       "default": "./src/plugins/cspell/*.ts"
     },
-    "./plugins/cspell/*/": {
-      "types": "./dist/types/plugins/cspell/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/cspell/index.mjs",
-      "require": "./dist/cjs/plugins/cspell/*/index.cjs",
-      "default": "./src/*/plugins/cspell/index.ts"
-    },
     "./plugins/cspell/*": {
       "types": "./dist/types/plugins/cspell/*",
       "import": "./dist/esm/plugins/cspell/*",
@@ -1099,12 +985,6 @@
       "import": "./dist/esm/plugins/eslint/*.mjs",
       "require": "./dist/cjs/plugins/eslint/*.cjs",
       "default": "./src/plugins/eslint/*.ts"
-    },
-    "./plugins/eslint/*/": {
-      "types": "./dist/types/plugins/eslint/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/eslint/index.mjs",
-      "require": "./dist/cjs/plugins/eslint/*/index.cjs",
-      "default": "./src/*/plugins/eslint/index.ts"
     },
     "./plugins/eslint/*": {
       "types": "./dist/types/plugins/eslint/*",
@@ -1152,12 +1032,6 @@
       "require": "./dist/cjs/plugins/globals/*.cjs",
       "default": "./src/plugins/globals/*.ts"
     },
-    "./plugins/globals/*/": {
-      "types": "./dist/types/plugins/globals/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/globals/index.mjs",
-      "require": "./dist/cjs/plugins/globals/*/index.cjs",
-      "default": "./src/*/plugins/globals/index.ts"
-    },
     "./plugins/globals/*": {
       "types": "./dist/types/plugins/globals/*",
       "import": "./dist/esm/plugins/globals/*",
@@ -1203,12 +1077,6 @@
       "import": "./dist/esm/plugins/ignores/*.mjs",
       "require": "./dist/cjs/plugins/ignores/*.cjs",
       "default": "./src/plugins/ignores/*.ts"
-    },
-    "./plugins/ignores/*/": {
-      "types": "./dist/types/plugins/ignores/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/ignores/index.mjs",
-      "require": "./dist/cjs/plugins/ignores/*/index.cjs",
-      "default": "./src/*/plugins/ignores/index.ts"
     },
     "./plugins/ignores/*": {
       "types": "./dist/types/plugins/ignores/*",
@@ -1256,12 +1124,6 @@
       "require": "./dist/cjs/plugins/import-x/*.cjs",
       "default": "./src/plugins/import-x/*.ts"
     },
-    "./plugins/import-x/*/": {
-      "types": "./dist/types/plugins/import-x/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/import-x/index.mjs",
-      "require": "./dist/cjs/plugins/import-x/*/index.cjs",
-      "default": "./src/*/plugins/import-x/index.ts"
-    },
     "./plugins/import-x/*": {
       "types": "./dist/types/plugins/import-x/*",
       "import": "./dist/esm/plugins/import-x/*",
@@ -1307,12 +1169,6 @@
       "import": "./dist/esm/plugins/jsdoc/*.mjs",
       "require": "./dist/cjs/plugins/jsdoc/*.cjs",
       "default": "./src/plugins/jsdoc/*.ts"
-    },
-    "./plugins/jsdoc/*/": {
-      "types": "./dist/types/plugins/jsdoc/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/jsdoc/index.mjs",
-      "require": "./dist/cjs/plugins/jsdoc/*/index.cjs",
-      "default": "./src/*/plugins/jsdoc/index.ts"
     },
     "./plugins/jsdoc/*": {
       "types": "./dist/types/plugins/jsdoc/*",
@@ -1360,12 +1216,6 @@
       "require": "./dist/cjs/plugins/n/*.cjs",
       "default": "./src/plugins/n/*.ts"
     },
-    "./plugins/n/*/": {
-      "types": "./dist/types/plugins/n/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/n/index.mjs",
-      "require": "./dist/cjs/plugins/n/*/index.cjs",
-      "default": "./src/*/plugins/n/index.ts"
-    },
     "./plugins/n/*": {
       "types": "./dist/types/plugins/n/*",
       "import": "./dist/esm/plugins/n/*",
@@ -1411,12 +1261,6 @@
       "import": "./dist/esm/plugins/perfectionist/*.mjs",
       "require": "./dist/cjs/plugins/perfectionist/*.cjs",
       "default": "./src/plugins/perfectionist/*.ts"
-    },
-    "./plugins/perfectionist/*/": {
-      "types": "./dist/types/plugins/perfectionist/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/perfectionist/index.mjs",
-      "require": "./dist/cjs/plugins/perfectionist/*/index.cjs",
-      "default": "./src/*/plugins/perfectionist/index.ts"
     },
     "./plugins/perfectionist/*": {
       "types": "./dist/types/plugins/perfectionist/*",
@@ -1464,12 +1308,6 @@
       "require": "./dist/cjs/plugins/stylistic/*.cjs",
       "default": "./src/plugins/stylistic/*.ts"
     },
-    "./plugins/stylistic/*/": {
-      "types": "./dist/types/plugins/stylistic/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/stylistic/index.mjs",
-      "require": "./dist/cjs/plugins/stylistic/*/index.cjs",
-      "default": "./src/*/plugins/stylistic/index.ts"
-    },
     "./plugins/stylistic/*": {
       "types": "./dist/types/plugins/stylistic/*",
       "import": "./dist/esm/plugins/stylistic/*",
@@ -1515,12 +1353,6 @@
       "import": "./dist/esm/plugins/typescript/*.mjs",
       "require": "./dist/cjs/plugins/typescript/*.cjs",
       "default": "./src/plugins/typescript/*.ts"
-    },
-    "./plugins/typescript/*/": {
-      "types": "./dist/types/plugins/typescript/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/typescript/index.mjs",
-      "require": "./dist/cjs/plugins/typescript/*/index.cjs",
-      "default": "./src/*/plugins/typescript/index.ts"
     },
     "./plugins/typescript/*": {
       "types": "./dist/types/plugins/typescript/*",
@@ -1568,12 +1400,6 @@
       "require": "./dist/cjs/plugins/yml/*.cjs",
       "default": "./src/plugins/yml/*.ts"
     },
-    "./plugins/yml/*/": {
-      "types": "./dist/types/plugins/yml/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/yml/index.mjs",
-      "require": "./dist/cjs/plugins/yml/*/index.cjs",
-      "default": "./src/*/plugins/yml/index.ts"
-    },
     "./plugins/yml/*": {
       "types": "./dist/types/plugins/yml/*",
       "import": "./dist/esm/plugins/yml/*",
@@ -1619,12 +1445,6 @@
       "import": "./dist/esm/constants/*.mjs",
       "require": "./dist/cjs/constants/*.cjs",
       "default": "./src/constants/*.ts"
-    },
-    "./constants/*/": {
-      "types": "./dist/types/constants/*/index.d.ts",
-      "import": "./dist/esm/*/constants/index.mjs",
-      "require": "./dist/cjs/constants/*/index.cjs",
-      "default": "./src/*/constants/index.ts"
     },
     "./constants/*": {
       "types": "./dist/types/constants/*",
@@ -1672,12 +1492,6 @@
       "require": "./dist/cjs/context/*.cjs",
       "default": "./src/context/*.ts"
     },
-    "./context/*/": {
-      "types": "./dist/types/context/*/index.d.ts",
-      "import": "./dist/esm/*/context/index.mjs",
-      "require": "./dist/cjs/context/*/index.cjs",
-      "default": "./src/*/context/index.ts"
-    },
     "./context/*": {
       "types": "./dist/types/context/*",
       "import": "./dist/esm/context/*",
@@ -1723,12 +1537,6 @@
       "import": "./dist/esm/eventing/*.mjs",
       "require": "./dist/cjs/eventing/*.cjs",
       "default": "./src/eventing/*.ts"
-    },
-    "./eventing/*/": {
-      "types": "./dist/types/eventing/*/index.d.ts",
-      "import": "./dist/esm/*/eventing/index.mjs",
-      "require": "./dist/cjs/eventing/*/index.cjs",
-      "default": "./src/*/eventing/index.ts"
     },
     "./eventing/*": {
       "types": "./dist/types/eventing/*",
@@ -1776,12 +1584,6 @@
       "require": "./dist/cjs/hooks/*.cjs",
       "default": "./src/hooks/*.ts"
     },
-    "./hooks/*/": {
-      "types": "./dist/types/hooks/*/index.d.ts",
-      "import": "./dist/esm/*/hooks/index.mjs",
-      "require": "./dist/cjs/hooks/*/index.cjs",
-      "default": "./src/*/hooks/index.ts"
-    },
     "./hooks/*": {
       "types": "./dist/types/hooks/*",
       "import": "./dist/esm/hooks/*",
@@ -1828,12 +1630,6 @@
       "require": "./dist/cjs/integration/*.cjs",
       "default": "./src/integration/*.ts"
     },
-    "./integration/*/": {
-      "types": "./dist/types/integration/*/index.d.ts",
-      "import": "./dist/esm/*/integration/index.mjs",
-      "require": "./dist/cjs/integration/*/index.cjs",
-      "default": "./src/*/integration/index.ts"
-    },
     "./integration/*": {
       "types": "./dist/types/integration/*",
       "import": "./dist/esm/integration/*",
@@ -1879,12 +1675,6 @@
       "import": "./dist/esm/plugins/*.mjs",
       "require": "./dist/cjs/plugins/*.cjs",
       "default": "./src/plugins/*.ts"
-    },
-    "./plugins/*/": {
-      "types": "./dist/types/plugins/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/index.mjs",
-      "require": "./dist/cjs/plugins/*/index.cjs",
-      "default": "./src/*/plugins/index.ts"
     },
     "./plugins/*": {
       "types": "./dist/types/plugins/*",

--- a/integrations/eslint/src/holypack.d.ts
+++ b/integrations/eslint/src/holypack.d.ts
@@ -1,1 +1,2 @@
 import "@holypack/core/module-augmentation.d.ts";
+import "@holypack/integration-typescript/module-augmentation.d.ts";

--- a/integrations/eslint/src/index.ts
+++ b/integrations/eslint/src/index.ts
@@ -4,5 +4,4 @@ export * from "./eventing";
 export * from "./hooks";
 export * from "./integration";
 export { createESLintIntegration as default } from "./integration";
-
 export * from "./plugins";

--- a/integrations/eslint/src/module-augmentation.ts
+++ b/integrations/eslint/src/module-augmentation.ts
@@ -1,23 +1,12 @@
 export type * from "./plugins/cspell/module-augmentation";
-
 export type * from "./plugins/eslint/js/module-augmentation";
-
 export type * from "./plugins/eslint/json/module-augmentation";
-
 export type * from "./plugins/eslint/markdown/module-augmentation";
-
 export type * from "./plugins/globals/module-augmentation";
-
 export type * from "./plugins/import-x/module-augmentation";
-
 export type * from "./plugins/jsdoc/module-augmentation";
-
 export type * from "./plugins/n/module-augmentation";
-
 export type * from "./plugins/perfectionist/module-augmentation";
-
 export type * from "./plugins/stylistic/module-augmentation";
-
 export type * from "./plugins/typescript/module-augmentation";
-
 export type * from "./plugins/yml/module-augmentation";

--- a/integrations/eslint/src/plugins/typescript/plugin-api.ts
+++ b/integrations/eslint/src/plugins/typescript/plugin-api.ts
@@ -36,6 +36,9 @@ export class ESLintIntegrationTypeScriptPluginAPI
     const resolvedOptions = resolveESLintIntegrationTypeScriptPluginOptions(
       context.cwd,
       options,
+      {
+        tsconfigRootDir: context.typescript.tsconfigRootDirectoryPath,
+      },
     );
 
     if (resolvedOptions === false)
@@ -73,7 +76,7 @@ export class ESLintIntegrationTypeScriptPluginAPI
       parserOptions: {
         projectService: true,
         tsconfigRootDir: resolvedOptions.tsconfigRootDir,
-        warnOnUnsupportedTypeScriptVersion: false,
+        warnOnUnsupportedTypeScriptVersion: resolvedOptions.warnOnUnsupportedTypeScriptVersion,
       },
     };
 

--- a/integrations/eslint/src/plugins/typescript/plugin-options-resolver.ts
+++ b/integrations/eslint/src/plugins/typescript/plugin-options-resolver.ts
@@ -6,6 +6,7 @@ import type {
 export function resolveESLintIntegrationTypeScriptPluginOptions(
   cwd: string,
   options?: boolean | ESLintIntegrationTypeScriptPluginOptions | null,
+  defaults?: ESLintIntegrationTypeScriptPluginOptions | null,
 ): ESLintIntegrationTypeScriptPluginResolvedOptions | false
 {
   if (options === false)
@@ -19,15 +20,23 @@ export function resolveESLintIntegrationTypeScriptPluginOptions(
       : options ?? {}
   );
 
-  // TODO(ertgl): Consider creating a plugin for workspaces.
-  // TODO(ertgl): Use `@holypack/core/utils/fs/root-path-finder` for tsconfigRootDir resolution.
+  defaults ??= {};
+
   const tsconfigRootDir = (
     optionsObject.tsconfigRootDir
+    ?? defaults.tsconfigRootDir
     ?? cwd
+  );
+
+  const warnOnUnsupportedTypeScriptVersion = (
+    optionsObject.warnOnUnsupportedTypeScriptVersion
+    ?? defaults.warnOnUnsupportedTypeScriptVersion
+    ?? false
   );
 
   return {
     ...optionsObject,
     tsconfigRootDir,
+    warnOnUnsupportedTypeScriptVersion,
   };
 }

--- a/integrations/eslint/src/plugins/typescript/plugin-options.ts
+++ b/integrations/eslint/src/plugins/typescript/plugin-options.ts
@@ -5,6 +5,7 @@ export type ESLintIntegrationTypeScriptPluginOptions = (
 
 export type ESLintIntegrationTypeScriptPluginOptionsBaseProperties = {
   tsconfigRootDir?: null | string;
+  warnOnUnsupportedTypeScriptVersion?: boolean | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -18,6 +19,7 @@ export type ESLintIntegrationTypeScriptPluginResolvedOptions = (
 
 export type ESLintIntegrationTypeScriptPluginResolvedOptionsBaseProperties = {
   tsconfigRootDir: string;
+  warnOnUnsupportedTypeScriptVersion: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/integrations/typescript/babel.config.cjs.mjs
+++ b/integrations/typescript/babel.config.cjs.mjs
@@ -1,0 +1,7 @@
+import { resolveConfig } from "@holypack/integration-babel";
+
+const BABEL_CONFIG = await resolveConfig({
+  targetExtension: ".cjs",
+});
+
+export default BABEL_CONFIG;

--- a/integrations/typescript/babel.config.esm.mjs
+++ b/integrations/typescript/babel.config.esm.mjs
@@ -1,0 +1,7 @@
+import { resolveConfig } from "@holypack/integration-babel";
+
+const BABEL_CONFIG = await resolveConfig({
+  targetExtension: ".mjs",
+});
+
+export default BABEL_CONFIG;

--- a/integrations/typescript/package.json
+++ b/integrations/typescript/package.json
@@ -17,6 +17,7 @@
     "@holypack/integration-babel": "workspace:^"
   },
   "files": [
+    "./dist/",
     "./src/",
     "./package.json"
   ],

--- a/integrations/typescript/package.json
+++ b/integrations/typescript/package.json
@@ -189,6 +189,52 @@
       "require": "./dist/cjs/presets/*",
       "default": "./src/presets/*"
     },
+    "./tsconfig-root-directory-path-finder": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/index.d.ts",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/index.mjs",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/index.cjs",
+      "default": "./src/tsconfig-root-directory-path-finder/index.ts"
+    },
+    "./tsconfig-root-directory-path-finder/": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/index.d.ts",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/index.mjs",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/index.cjs",
+      "default": "./src/tsconfig-root-directory-path-finder/index.ts"
+    },
+    "./tsconfig-root-directory-path-finder/*.d.ts": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/*.d.ts",
+      "default": "./src/tsconfig-root-directory-path-finder/*.ts"
+    },
+    "./tsconfig-root-directory-path-finder/*.cjs": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/*.d.ts",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/*.mjs",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/*.cjs",
+      "default": "./src/tsconfig-root-directory-path-finder/*.ts"
+    },
+    "./tsconfig-root-directory-path-finder/*.js": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/*.d.ts",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/*.mjs",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/*.cjs",
+      "default": "./src/tsconfig-root-directory-path-finder/*.ts"
+    },
+    "./tsconfig-root-directory-path-finder/*.mjs": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/*.d.ts",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/*.mjs",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/*.cjs",
+      "default": "./src/tsconfig-root-directory-path-finder/*.ts"
+    },
+    "./tsconfig-root-directory-path-finder/*.ts": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/*.d.ts",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/*.mjs",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/*.cjs",
+      "default": "./src/tsconfig-root-directory-path-finder/*.ts"
+    },
+    "./tsconfig-root-directory-path-finder/*": {
+      "types": "./dist/types/tsconfig-root-directory-path-finder/*",
+      "import": "./dist/esm/tsconfig-root-directory-path-finder/*",
+      "require": "./dist/cjs/tsconfig-root-directory-path-finder/*",
+      "default": "./src/tsconfig-root-directory-path-finder/*"
+    },
     "./*.d.ts": {
       "types": "./dist/types/*.d.ts",
       "default": "./src/*.ts"

--- a/integrations/typescript/package.json
+++ b/integrations/typescript/package.json
@@ -1,11 +1,20 @@
 {
   "name": "@holypack/integration-typescript",
   "scripts": {
+    "build": "yarn clean && yarn babel:build::cjs && yarn babel:build::esm && yarn tsc:build::types && yarn hack:update-package-exports",
+    "clean": "rm -fr dist",
     "tsc:build::types": "cd $INIT_CWD && tsc --project ./tsconfig.output.types.json && node -e \"console.log('Successfully built types.')\"",
     "tsc:check::types": "cd $INIT_CWD && tsc --noEmit"
   },
+  "peerDependencies": {
+    "@holypack/core": "*"
+  },
   "dependencies": {
     "typescript": "^5.8.3"
+  },
+  "devDependencies": {
+    "@holypack/core": "workspace:^",
+    "@holypack/integration-babel": "workspace:^"
   },
   "files": [
     "./src/",
@@ -13,7 +22,212 @@
   ],
   "exports": {
     "./package.json": "./package.json",
-    "./presets/*.json": "./src/presets/*.json",
-    "./*.json": "./src/*.json"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs",
+      "default": "./src/index.ts"
+    },
+    "./integration/module-augmentation": {
+      "types": "./dist/types/integration/module-augmentation/index.d.ts",
+      "import": "./dist/esm/integration/module-augmentation/index.mjs",
+      "require": "./dist/cjs/integration/module-augmentation/index.cjs",
+      "default": "./src/integration/module-augmentation/index.ts"
+    },
+    "./integration/module-augmentation/": {
+      "types": "./dist/types/integration/module-augmentation/index.d.ts",
+      "import": "./dist/esm/integration/module-augmentation/index.mjs",
+      "require": "./dist/cjs/integration/module-augmentation/index.cjs",
+      "default": "./src/integration/module-augmentation/index.ts"
+    },
+    "./integration/module-augmentation/*.d.ts": {
+      "types": "./dist/types/integration/module-augmentation/*.d.ts",
+      "default": "./src/integration/module-augmentation/*.ts"
+    },
+    "./integration/module-augmentation/*.cjs": {
+      "types": "./dist/types/integration/module-augmentation/*.d.ts",
+      "import": "./dist/esm/integration/module-augmentation/*.mjs",
+      "require": "./dist/cjs/integration/module-augmentation/*.cjs",
+      "default": "./src/integration/module-augmentation/*.ts"
+    },
+    "./integration/module-augmentation/*.js": {
+      "types": "./dist/types/integration/module-augmentation/*.d.ts",
+      "import": "./dist/esm/integration/module-augmentation/*.mjs",
+      "require": "./dist/cjs/integration/module-augmentation/*.cjs",
+      "default": "./src/integration/module-augmentation/*.ts"
+    },
+    "./integration/module-augmentation/*.mjs": {
+      "types": "./dist/types/integration/module-augmentation/*.d.ts",
+      "import": "./dist/esm/integration/module-augmentation/*.mjs",
+      "require": "./dist/cjs/integration/module-augmentation/*.cjs",
+      "default": "./src/integration/module-augmentation/*.ts"
+    },
+    "./integration/module-augmentation/*.ts": {
+      "types": "./dist/types/integration/module-augmentation/*.d.ts",
+      "import": "./dist/esm/integration/module-augmentation/*.mjs",
+      "require": "./dist/cjs/integration/module-augmentation/*.cjs",
+      "default": "./src/integration/module-augmentation/*.ts"
+    },
+    "./integration/module-augmentation/*": {
+      "types": "./dist/types/integration/module-augmentation/*",
+      "import": "./dist/esm/integration/module-augmentation/*",
+      "require": "./dist/cjs/integration/module-augmentation/*",
+      "default": "./src/integration/module-augmentation/*"
+    },
+    "./context": {
+      "types": "./dist/types/context/index.d.ts",
+      "import": "./dist/esm/context/index.mjs",
+      "require": "./dist/cjs/context/index.cjs",
+      "default": "./src/context/index.ts"
+    },
+    "./context/": {
+      "types": "./dist/types/context/index.d.ts",
+      "import": "./dist/esm/context/index.mjs",
+      "require": "./dist/cjs/context/index.cjs",
+      "default": "./src/context/index.ts"
+    },
+    "./context/*.d.ts": {
+      "types": "./dist/types/context/*.d.ts",
+      "default": "./src/context/*.ts"
+    },
+    "./context/*.cjs": {
+      "types": "./dist/types/context/*.d.ts",
+      "import": "./dist/esm/context/*.mjs",
+      "require": "./dist/cjs/context/*.cjs",
+      "default": "./src/context/*.ts"
+    },
+    "./context/*.js": {
+      "types": "./dist/types/context/*.d.ts",
+      "import": "./dist/esm/context/*.mjs",
+      "require": "./dist/cjs/context/*.cjs",
+      "default": "./src/context/*.ts"
+    },
+    "./context/*.mjs": {
+      "types": "./dist/types/context/*.d.ts",
+      "import": "./dist/esm/context/*.mjs",
+      "require": "./dist/cjs/context/*.cjs",
+      "default": "./src/context/*.ts"
+    },
+    "./context/*.ts": {
+      "types": "./dist/types/context/*.d.ts",
+      "import": "./dist/esm/context/*.mjs",
+      "require": "./dist/cjs/context/*.cjs",
+      "default": "./src/context/*.ts"
+    },
+    "./context/*": {
+      "types": "./dist/types/context/*",
+      "import": "./dist/esm/context/*",
+      "require": "./dist/cjs/context/*",
+      "default": "./src/context/*"
+    },
+    "./integration": {
+      "types": "./dist/types/integration/index.d.ts",
+      "import": "./dist/esm/integration/index.mjs",
+      "require": "./dist/cjs/integration/index.cjs",
+      "default": "./src/integration/index.ts"
+    },
+    "./integration/": {
+      "types": "./dist/types/integration/index.d.ts",
+      "import": "./dist/esm/integration/index.mjs",
+      "require": "./dist/cjs/integration/index.cjs",
+      "default": "./src/integration/index.ts"
+    },
+    "./integration/*.d.ts": {
+      "types": "./dist/types/integration/*.d.ts",
+      "default": "./src/integration/*.ts"
+    },
+    "./integration/*.cjs": {
+      "types": "./dist/types/integration/*.d.ts",
+      "import": "./dist/esm/integration/*.mjs",
+      "require": "./dist/cjs/integration/*.cjs",
+      "default": "./src/integration/*.ts"
+    },
+    "./integration/*.js": {
+      "types": "./dist/types/integration/*.d.ts",
+      "import": "./dist/esm/integration/*.mjs",
+      "require": "./dist/cjs/integration/*.cjs",
+      "default": "./src/integration/*.ts"
+    },
+    "./integration/*.mjs": {
+      "types": "./dist/types/integration/*.d.ts",
+      "import": "./dist/esm/integration/*.mjs",
+      "require": "./dist/cjs/integration/*.cjs",
+      "default": "./src/integration/*.ts"
+    },
+    "./integration/*.ts": {
+      "types": "./dist/types/integration/*.d.ts",
+      "import": "./dist/esm/integration/*.mjs",
+      "require": "./dist/cjs/integration/*.cjs",
+      "default": "./src/integration/*.ts"
+    },
+    "./integration/*": {
+      "types": "./dist/types/integration/*",
+      "import": "./dist/esm/integration/*",
+      "require": "./dist/cjs/integration/*",
+      "default": "./src/integration/*"
+    },
+    "./presets": {
+      "types": "./dist/types/presets/index.d.ts",
+      "import": "./dist/esm/presets/index.mjs",
+      "require": "./dist/cjs/presets/index.cjs",
+      "default": "./src/presets/index.ts"
+    },
+    "./presets/": {
+      "types": "./dist/types/presets/index.d.ts",
+      "import": "./dist/esm/presets/index.mjs",
+      "require": "./dist/cjs/presets/index.cjs",
+      "default": "./src/presets/index.ts"
+    },
+    "./presets/*.json": {
+      "import": "./dist/esm/presets/*.json",
+      "require": "./dist/cjs/presets/*.json",
+      "default": "./src/presets/*.json"
+    },
+    "./presets/*": {
+      "types": "./dist/types/presets/*",
+      "import": "./dist/esm/presets/*",
+      "require": "./dist/cjs/presets/*",
+      "default": "./src/presets/*"
+    },
+    "./*.d.ts": {
+      "types": "./dist/types/*.d.ts",
+      "default": "./src/*.ts"
+    },
+    "./*.cjs": {
+      "types": "./dist/types/*.d.ts",
+      "import": "./dist/esm/*.mjs",
+      "require": "./dist/cjs/*.cjs",
+      "default": "./src/*.ts"
+    },
+    "./*.js": {
+      "types": "./dist/types/*.d.ts",
+      "import": "./dist/esm/*.mjs",
+      "require": "./dist/cjs/*.cjs",
+      "default": "./src/*.ts"
+    },
+    "./*.mjs": {
+      "types": "./dist/types/*.d.ts",
+      "import": "./dist/esm/*.mjs",
+      "require": "./dist/cjs/*.cjs",
+      "default": "./src/*.ts"
+    },
+    "./*.ts": {
+      "types": "./dist/types/*.d.ts",
+      "import": "./dist/esm/*.mjs",
+      "require": "./dist/cjs/*.cjs",
+      "default": "./src/*.ts"
+    },
+    "./*/": {
+      "types": "./dist/types/*/index.d.ts",
+      "import": "./dist/esm/*/index.mjs",
+      "require": "./dist/cjs/*/index.cjs",
+      "default": "./src/*/index.ts"
+    },
+    "./*": {
+      "types": "./dist/types/*",
+      "import": "./dist/esm/*",
+      "require": "./dist/cjs/*",
+      "default": "./src/*"
+    }
   }
 }

--- a/integrations/typescript/src/context/context.ts
+++ b/integrations/typescript/src/context/context.ts
@@ -1,0 +1,25 @@
+export type TypeScriptContext = (
+  & TypeScriptContextBaseProperties
+  & TypeScriptContextCustomProperties
+);
+
+export type TypeScriptContextBaseProperties = {
+  tsconfigDirectoryPaths?: string[];
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TypeScriptContextCustomProperties
+{}
+
+export type TypeScriptResolvedContext = (
+  & TypeScriptResolvedContextBaseProperties
+  & TypeScriptResolvedContextCustomProperties
+);
+
+export type TypeScriptResolvedContextBaseProperties = {
+  tsconfigDirectoryPaths: string[];
+};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TypeScriptResolvedContextCustomProperties
+{}

--- a/integrations/typescript/src/context/context.ts
+++ b/integrations/typescript/src/context/context.ts
@@ -4,7 +4,7 @@ export type TypeScriptContext = (
 );
 
 export type TypeScriptContextBaseProperties = {
-  tsconfigDirectoryPaths?: string[];
+  tsconfigRootDirectoryPath?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -17,7 +17,7 @@ export type TypeScriptResolvedContext = (
 );
 
 export type TypeScriptResolvedContextBaseProperties = {
-  tsconfigDirectoryPaths: string[];
+  tsconfigRootDirectoryPath: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/integrations/typescript/src/context/index.ts
+++ b/integrations/typescript/src/context/index.ts
@@ -1,0 +1,1 @@
+export * from "./context";

--- a/integrations/typescript/src/holypack.d.ts
+++ b/integrations/typescript/src/holypack.d.ts
@@ -1,0 +1,1 @@
+import "@holypack/core/module-augmentation.d.ts";

--- a/integrations/typescript/src/index.ts
+++ b/integrations/typescript/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./context";
+export * from "./integration";
+export { createTypeScriptIntegration as default } from "./integration";

--- a/integrations/typescript/src/integration/index.ts
+++ b/integrations/typescript/src/integration/index.ts
@@ -1,0 +1,3 @@
+export * from "./integration";
+export * from "./integration-options";
+export * from "./module-augmentation";

--- a/integrations/typescript/src/integration/integration-api.ts
+++ b/integrations/typescript/src/integration/integration-api.ts
@@ -1,0 +1,36 @@
+import type {
+  Context,
+  ResolvedContext,
+} from "@holypack/core";
+
+import {
+  findTSConfigRootDirectoryPath,
+  type TSConfigRootDirectoryPathFinderOptions,
+} from "../tsconfig-root-directory-path-finder";
+
+import type { TypeScriptIntegration } from "./integration";
+
+export class TypeScriptIntegrationAPI
+{
+  integration: TypeScriptIntegration;
+
+  constructor(
+    integration: TypeScriptIntegration,
+  )
+  {
+    this.integration = integration;
+  }
+
+  async findTSConfigRootDirectoryPath(
+    context: Context | ResolvedContext,
+    options?: null | TSConfigRootDirectoryPathFinderOptions,
+  ): Promise<string>
+  {
+    const cwd = options?.cwd ?? context.cwd;
+
+    return await findTSConfigRootDirectoryPath({
+      ...options,
+      cwd,
+    });
+  }
+}

--- a/integrations/typescript/src/integration/integration-options.ts
+++ b/integrations/typescript/src/integration/integration-options.ts
@@ -1,0 +1,11 @@
+export type TypeScriptIntegrationOptions = (
+  & TypeScriptIntegrationOptionsBaseProperties
+  & TypeScriptIntegrationOptionsCustomProperties
+);
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type TypeScriptIntegrationOptionsBaseProperties = {};
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface TypeScriptIntegrationOptionsCustomProperties
+{}

--- a/integrations/typescript/src/integration/integration-options.ts
+++ b/integrations/typescript/src/integration/integration-options.ts
@@ -3,8 +3,9 @@ export type TypeScriptIntegrationOptions = (
   & TypeScriptIntegrationOptionsCustomProperties
 );
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type TypeScriptIntegrationOptionsBaseProperties = {};
+export type TypeScriptIntegrationOptionsBaseProperties = {
+  tsconfigRootDirectoryPath?: null | string;
+};
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TypeScriptIntegrationOptionsCustomProperties

--- a/integrations/typescript/src/integration/integration.ts
+++ b/integrations/typescript/src/integration/integration.ts
@@ -4,12 +4,15 @@ import type {
   Integration,
 } from "@holypack/core";
 
+import { TypeScriptIntegrationAPI } from "./integration-api";
 import type { TypeScriptIntegrationOptions } from "./integration-options";
 
 export const INTEGRATION_NAME_TYPESCRIPT = "@holypack/integration:TypeScript";
 
 export class TypeScriptIntegration implements Integration
 {
+  api: TypeScriptIntegrationAPI;
+
   name = INTEGRATION_NAME_TYPESCRIPT;
 
   options: TypeScriptIntegrationOptions;
@@ -18,16 +21,23 @@ export class TypeScriptIntegration implements Integration
     options?: null | TypeScriptIntegrationOptions,
   )
   {
+    this.api = new TypeScriptIntegrationAPI(this);
     this.options = options ?? {};
   }
 
-  resolveContext(
+  async resolveContext(
     context: Context,
     options: ContextResolutionOptions,
-  ): void
+  ): Promise<void>
   {
-    // TODO(ertgl): Resolve TypeScript related context.
-    context.typescript = {};
+    const tsconfigRootDirectoryPath = (
+      this.options.tsconfigRootDirectoryPath
+      ?? await this.api.findTSConfigRootDirectoryPath(context)
+    );
+
+    context.typescript = {
+      tsconfigRootDirectoryPath,
+    };
   }
 }
 

--- a/integrations/typescript/src/integration/integration.ts
+++ b/integrations/typescript/src/integration/integration.ts
@@ -1,0 +1,39 @@
+import type {
+  Context,
+  ContextResolutionOptions,
+  Integration,
+} from "@holypack/core";
+
+import type { TypeScriptIntegrationOptions } from "./integration-options";
+
+export const INTEGRATION_NAME_TYPESCRIPT = "@holypack/integration:TypeScript";
+
+export class TypeScriptIntegration implements Integration
+{
+  name = INTEGRATION_NAME_TYPESCRIPT;
+
+  options: TypeScriptIntegrationOptions;
+
+  constructor(
+    options?: null | TypeScriptIntegrationOptions,
+  )
+  {
+    this.options = options ?? {};
+  }
+
+  resolveContext(
+    context: Context,
+    options: ContextResolutionOptions,
+  ): void
+  {
+    // TODO(ertgl): Resolve TypeScript related context.
+    context.typescript = {};
+  }
+}
+
+export function createTypeScriptIntegration(
+  options?: null | TypeScriptIntegrationOptions,
+): TypeScriptIntegration
+{
+  return new TypeScriptIntegration(options);
+}

--- a/integrations/typescript/src/integration/module-augmentation/context.ts
+++ b/integrations/typescript/src/integration/module-augmentation/context.ts
@@ -1,0 +1,19 @@
+import type {
+  TypeScriptContext,
+  TypeScriptResolvedContext,
+} from "../../context";
+
+declare module "@holypack/core"
+{
+  interface ContextCustomProperties
+  {
+    typescript?: null | TypeScriptContext;
+  }
+
+  interface ResolvedContextCustomProperties
+  {
+    typescript: TypeScriptResolvedContext;
+  }
+}
+
+export {};

--- a/integrations/typescript/src/integration/module-augmentation/index.ts
+++ b/integrations/typescript/src/integration/module-augmentation/index.ts
@@ -1,0 +1,1 @@
+export * from "./context";

--- a/integrations/typescript/src/module-augmentation.ts
+++ b/integrations/typescript/src/module-augmentation.ts
@@ -1,0 +1,1 @@
+export type * from "./integration/module-augmentation";

--- a/integrations/typescript/src/tsconfig-root-directory-path-finder/finder.ts
+++ b/integrations/typescript/src/tsconfig-root-directory-path-finder/finder.ts
@@ -1,0 +1,33 @@
+import {
+  findRootPath,
+  ROOT_PATH_FINDER_TARGET_INNERMOST,
+  type RootPathFinderOptions,
+} from "@holypack/core/utils/fs/root-path-finder";
+import { resolveCWD } from "@holypack/core/utils/process/cwd";
+
+import type { TSConfigRootDirectoryPathFinderOptions } from "./options";
+
+export async function findTSConfigRootDirectoryPath(
+  options?: null | TSConfigRootDirectoryPathFinderOptions,
+): Promise<string>
+{
+  options ??= {};
+
+  const cwd = resolveCWD(options.cwd);
+
+  const rootPathFinderOptions: RootPathFinderOptions = {
+    fs: options.fs,
+    includeSelf: true,
+    target: ROOT_PATH_FINDER_TARGET_INNERMOST,
+  };
+
+  const rootPathFinderLookupPaths = [
+    "tsconfig.json",
+  ];
+
+  return await findRootPath(
+    cwd,
+    rootPathFinderLookupPaths,
+    rootPathFinderOptions,
+  );
+}

--- a/integrations/typescript/src/tsconfig-root-directory-path-finder/fs.ts
+++ b/integrations/typescript/src/tsconfig-root-directory-path-finder/fs.ts
@@ -1,0 +1,5 @@
+import type { RootPathFinderFS } from "@holypack/core/utils/fs/root-path-finder";
+
+export type TSConfigRootDirectoryPathFinderFS = (
+  & RootPathFinderFS
+);

--- a/integrations/typescript/src/tsconfig-root-directory-path-finder/index.ts
+++ b/integrations/typescript/src/tsconfig-root-directory-path-finder/index.ts
@@ -1,0 +1,3 @@
+export * from "./finder";
+export * from "./fs";
+export * from "./options";

--- a/integrations/typescript/src/tsconfig-root-directory-path-finder/options.ts
+++ b/integrations/typescript/src/tsconfig-root-directory-path-finder/options.ts
@@ -1,0 +1,6 @@
+import type { TSConfigRootDirectoryPathFinderFS } from "./fs";
+
+export type TSConfigRootDirectoryPathFinderOptions = {
+  cwd?: null | string;
+  fs?: null | TSConfigRootDirectoryPathFinderFS;
+};

--- a/integrations/typescript/tsconfig.json
+++ b/integrations/typescript/tsconfig.json
@@ -2,6 +2,15 @@
   "files": [],
   "references": [
     {
+      "path": "./tsconfig.scope.dist.cjs.json"
+    },
+    {
+      "path": "./tsconfig.scope.dist.esm.json"
+    },
+    {
+      "path": "./tsconfig.scope.dist.types.json"
+    },
+    {
       "path": "./tsconfig.scope.src.json"
     },
     {

--- a/integrations/typescript/tsconfig.output.types.json
+++ b/integrations/typescript/tsconfig.output.types.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./src/presets/tsconfig.output.types.json"
+}

--- a/integrations/typescript/tsconfig.scope.dist.cjs.json
+++ b/integrations/typescript/tsconfig.scope.dist.cjs.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./src/presets/tsconfig.scope.dist.cjs.json"
+}

--- a/integrations/typescript/tsconfig.scope.dist.esm.json
+++ b/integrations/typescript/tsconfig.scope.dist.esm.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./src/presets/tsconfig.scope.dist.esm.json"
+}

--- a/integrations/typescript/tsconfig.scope.dist.types.json
+++ b/integrations/typescript/tsconfig.scope.dist.types.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./src/presets/tsconfig.scope.dist.types.json"
+}

--- a/internal/integrations/node/package.json
+++ b/internal/integrations/node/package.json
@@ -5,7 +5,7 @@
     "cmd:node": "cd $INIT_CWD && node"
   },
   "devDependencies": {
-    "@types/node": "^22.14.1"
+    "@types/node": "^22.15.2"
   },
   "files": [
     "./package.json"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@holypack/eslint-plugin": "workspace:*",
     "@holypack/integration-eslint": "workspace:*",
+    "@holypack/integration-typescript": "workspace:*",
     "holypack": "workspace:*"
   },
   "resolutions": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,12 +76,6 @@
       "require": "./dist/cjs/context/warnings/*.cjs",
       "default": "./src/context/warnings/*.ts"
     },
-    "./context/warnings/*/": {
-      "types": "./dist/types/context/warnings/*/index.d.ts",
-      "import": "./dist/esm/*/context/warnings/index.mjs",
-      "require": "./dist/cjs/context/warnings/*/index.cjs",
-      "default": "./src/*/context/warnings/index.ts"
-    },
     "./context/warnings/*": {
       "types": "./dist/types/context/warnings/*",
       "import": "./dist/esm/context/warnings/*",
@@ -127,12 +121,6 @@
       "import": "./dist/esm/eventing/errors/*.mjs",
       "require": "./dist/cjs/eventing/errors/*.cjs",
       "default": "./src/eventing/errors/*.ts"
-    },
-    "./eventing/errors/*/": {
-      "types": "./dist/types/eventing/errors/*/index.d.ts",
-      "import": "./dist/esm/*/eventing/errors/index.mjs",
-      "require": "./dist/cjs/eventing/errors/*/index.cjs",
-      "default": "./src/*/eventing/errors/index.ts"
     },
     "./eventing/errors/*": {
       "types": "./dist/types/eventing/errors/*",
@@ -180,12 +168,6 @@
       "require": "./dist/cjs/extension/errors/*.cjs",
       "default": "./src/extension/errors/*.ts"
     },
-    "./extension/errors/*/": {
-      "types": "./dist/types/extension/errors/*/index.d.ts",
-      "import": "./dist/esm/*/extension/errors/index.mjs",
-      "require": "./dist/cjs/extension/errors/*/index.cjs",
-      "default": "./src/*/extension/errors/index.ts"
-    },
     "./extension/errors/*": {
       "types": "./dist/types/extension/errors/*",
       "import": "./dist/esm/extension/errors/*",
@@ -231,12 +213,6 @@
       "import": "./dist/esm/integration/errors/*.mjs",
       "require": "./dist/cjs/integration/errors/*.cjs",
       "default": "./src/integration/errors/*.ts"
-    },
-    "./integration/errors/*/": {
-      "types": "./dist/types/integration/errors/*/index.d.ts",
-      "import": "./dist/esm/*/integration/errors/index.mjs",
-      "require": "./dist/cjs/integration/errors/*/index.cjs",
-      "default": "./src/*/integration/errors/index.ts"
     },
     "./integration/errors/*": {
       "types": "./dist/types/integration/errors/*",
@@ -284,12 +260,6 @@
       "require": "./dist/cjs/module/errors/*.cjs",
       "default": "./src/module/errors/*.ts"
     },
-    "./module/errors/*/": {
-      "types": "./dist/types/module/errors/*/index.d.ts",
-      "import": "./dist/esm/*/module/errors/index.mjs",
-      "require": "./dist/cjs/module/errors/*/index.cjs",
-      "default": "./src/*/module/errors/index.ts"
-    },
     "./module/errors/*": {
       "types": "./dist/types/module/errors/*",
       "import": "./dist/esm/module/errors/*",
@@ -335,12 +305,6 @@
       "import": "./dist/esm/plugins/package/utils/fields/workspaces/*.mjs",
       "require": "./dist/cjs/plugins/package/utils/fields/workspaces/*.cjs",
       "default": "./src/plugins/package/utils/fields/workspaces/*.ts"
-    },
-    "./plugins/package/utils/fields/workspaces/*/": {
-      "types": "./dist/types/plugins/package/utils/fields/workspaces/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/package/utils/fields/workspaces/index.mjs",
-      "require": "./dist/cjs/plugins/package/utils/fields/workspaces/*/index.cjs",
-      "default": "./src/*/plugins/package/utils/fields/workspaces/index.ts"
     },
     "./plugins/package/utils/fields/workspaces/*": {
       "types": "./dist/types/plugins/package/utils/fields/workspaces/*",
@@ -388,12 +352,6 @@
       "require": "./dist/cjs/plugins/package/utils/fields/*.cjs",
       "default": "./src/plugins/package/utils/fields/*.ts"
     },
-    "./plugins/package/utils/fields/*/": {
-      "types": "./dist/types/plugins/package/utils/fields/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/package/utils/fields/index.mjs",
-      "require": "./dist/cjs/plugins/package/utils/fields/*/index.cjs",
-      "default": "./src/*/plugins/package/utils/fields/index.ts"
-    },
     "./plugins/package/utils/fields/*": {
       "types": "./dist/types/plugins/package/utils/fields/*",
       "import": "./dist/esm/plugins/package/utils/fields/*",
@@ -439,12 +397,6 @@
       "import": "./dist/esm/plugins/package/utils/module/*.mjs",
       "require": "./dist/cjs/plugins/package/utils/module/*.cjs",
       "default": "./src/plugins/package/utils/module/*.ts"
-    },
-    "./plugins/package/utils/module/*/": {
-      "types": "./dist/types/plugins/package/utils/module/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/package/utils/module/index.mjs",
-      "require": "./dist/cjs/plugins/package/utils/module/*/index.cjs",
-      "default": "./src/*/plugins/package/utils/module/index.ts"
     },
     "./plugins/package/utils/module/*": {
       "types": "./dist/types/plugins/package/utils/module/*",
@@ -492,12 +444,6 @@
       "require": "./dist/cjs/plugins/package/utils/*.cjs",
       "default": "./src/plugins/package/utils/*.ts"
     },
-    "./plugins/package/utils/*/": {
-      "types": "./dist/types/plugins/package/utils/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/package/utils/index.mjs",
-      "require": "./dist/cjs/plugins/package/utils/*/index.cjs",
-      "default": "./src/*/plugins/package/utils/index.ts"
-    },
     "./plugins/package/utils/*": {
       "types": "./dist/types/plugins/package/utils/*",
       "import": "./dist/esm/plugins/package/utils/*",
@@ -543,12 +489,6 @@
       "import": "./dist/esm/plugins/process/plugins/warning-monitor/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/process/plugins/warning-monitor/module-augmentation/*.cjs",
       "default": "./src/plugins/process/plugins/warning-monitor/module-augmentation/*.ts"
-    },
-    "./plugins/process/plugins/warning-monitor/module-augmentation/*/": {
-      "types": "./dist/types/plugins/process/plugins/warning-monitor/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/process/plugins/warning-monitor/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/process/plugins/warning-monitor/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/process/plugins/warning-monitor/module-augmentation/index.ts"
     },
     "./plugins/process/plugins/warning-monitor/module-augmentation/*": {
       "types": "./dist/types/plugins/process/plugins/warning-monitor/module-augmentation/*",
@@ -596,12 +536,6 @@
       "require": "./dist/cjs/plugins/process/plugins/cwd/*.cjs",
       "default": "./src/plugins/process/plugins/cwd/*.ts"
     },
-    "./plugins/process/plugins/cwd/*/": {
-      "types": "./dist/types/plugins/process/plugins/cwd/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/process/plugins/cwd/index.mjs",
-      "require": "./dist/cjs/plugins/process/plugins/cwd/*/index.cjs",
-      "default": "./src/*/plugins/process/plugins/cwd/index.ts"
-    },
     "./plugins/process/plugins/cwd/*": {
       "types": "./dist/types/plugins/process/plugins/cwd/*",
       "import": "./dist/esm/plugins/process/plugins/cwd/*",
@@ -647,12 +581,6 @@
       "import": "./dist/esm/plugins/process/plugins/warning-monitor/*.mjs",
       "require": "./dist/cjs/plugins/process/plugins/warning-monitor/*.cjs",
       "default": "./src/plugins/process/plugins/warning-monitor/*.ts"
-    },
-    "./plugins/process/plugins/warning-monitor/*/": {
-      "types": "./dist/types/plugins/process/plugins/warning-monitor/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/process/plugins/warning-monitor/index.mjs",
-      "require": "./dist/cjs/plugins/process/plugins/warning-monitor/*/index.cjs",
-      "default": "./src/*/plugins/process/plugins/warning-monitor/index.ts"
     },
     "./plugins/process/plugins/warning-monitor/*": {
       "types": "./dist/types/plugins/process/plugins/warning-monitor/*",
@@ -700,12 +628,6 @@
       "require": "./dist/cjs/plugins/process/module-augmentation/*.cjs",
       "default": "./src/plugins/process/module-augmentation/*.ts"
     },
-    "./plugins/process/module-augmentation/*/": {
-      "types": "./dist/types/plugins/process/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/process/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/process/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/process/module-augmentation/index.ts"
-    },
     "./plugins/process/module-augmentation/*": {
       "types": "./dist/types/plugins/process/module-augmentation/*",
       "import": "./dist/esm/plugins/process/module-augmentation/*",
@@ -751,12 +673,6 @@
       "import": "./dist/esm/plugins/process/plugins/*.mjs",
       "require": "./dist/cjs/plugins/process/plugins/*.cjs",
       "default": "./src/plugins/process/plugins/*.ts"
-    },
-    "./plugins/process/plugins/*/": {
-      "types": "./dist/types/plugins/process/plugins/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/process/plugins/index.mjs",
-      "require": "./dist/cjs/plugins/process/plugins/*/index.cjs",
-      "default": "./src/*/plugins/process/plugins/index.ts"
     },
     "./plugins/process/plugins/*": {
       "types": "./dist/types/plugins/process/plugins/*",
@@ -804,12 +720,6 @@
       "require": "./dist/cjs/plugins/project/eventing/*.cjs",
       "default": "./src/plugins/project/eventing/*.ts"
     },
-    "./plugins/project/eventing/*/": {
-      "types": "./dist/types/plugins/project/eventing/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/project/eventing/index.mjs",
-      "require": "./dist/cjs/plugins/project/eventing/*/index.cjs",
-      "default": "./src/*/plugins/project/eventing/index.ts"
-    },
     "./plugins/project/eventing/*": {
       "types": "./dist/types/plugins/project/eventing/*",
       "import": "./dist/esm/plugins/project/eventing/*",
@@ -855,12 +765,6 @@
       "import": "./dist/esm/plugins/project/hooks/*.mjs",
       "require": "./dist/cjs/plugins/project/hooks/*.cjs",
       "default": "./src/plugins/project/hooks/*.ts"
-    },
-    "./plugins/project/hooks/*/": {
-      "types": "./dist/types/plugins/project/hooks/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/project/hooks/index.mjs",
-      "require": "./dist/cjs/plugins/project/hooks/*/index.cjs",
-      "default": "./src/*/plugins/project/hooks/index.ts"
     },
     "./plugins/project/hooks/*": {
       "types": "./dist/types/plugins/project/hooks/*",
@@ -908,12 +812,6 @@
       "require": "./dist/cjs/plugins/project/module-augmentation/*.cjs",
       "default": "./src/plugins/project/module-augmentation/*.ts"
     },
-    "./plugins/project/module-augmentation/*/": {
-      "types": "./dist/types/plugins/project/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/project/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/project/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/project/module-augmentation/index.ts"
-    },
     "./plugins/project/module-augmentation/*": {
       "types": "./dist/types/plugins/project/module-augmentation/*",
       "import": "./dist/esm/plugins/project/module-augmentation/*",
@@ -959,12 +857,6 @@
       "import": "./dist/esm/plugins/project/resolution/*.mjs",
       "require": "./dist/cjs/plugins/project/resolution/*.cjs",
       "default": "./src/plugins/project/resolution/*.ts"
-    },
-    "./plugins/project/resolution/*/": {
-      "types": "./dist/types/plugins/project/resolution/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/project/resolution/index.mjs",
-      "require": "./dist/cjs/plugins/project/resolution/*/index.cjs",
-      "default": "./src/*/plugins/project/resolution/index.ts"
     },
     "./plugins/project/resolution/*": {
       "types": "./dist/types/plugins/project/resolution/*",
@@ -1012,12 +904,6 @@
       "require": "./dist/cjs/plugins/project/root-path-finder/*.cjs",
       "default": "./src/plugins/project/root-path-finder/*.ts"
     },
-    "./plugins/project/root-path-finder/*/": {
-      "types": "./dist/types/plugins/project/root-path-finder/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/project/root-path-finder/index.mjs",
-      "require": "./dist/cjs/plugins/project/root-path-finder/*/index.cjs",
-      "default": "./src/*/plugins/project/root-path-finder/index.ts"
-    },
     "./plugins/project/root-path-finder/*": {
       "types": "./dist/types/plugins/project/root-path-finder/*",
       "import": "./dist/esm/plugins/project/root-path-finder/*",
@@ -1063,12 +949,6 @@
       "import": "./dist/esm/plugins/repository/module-augmentation/*.mjs",
       "require": "./dist/cjs/plugins/repository/module-augmentation/*.cjs",
       "default": "./src/plugins/repository/module-augmentation/*.ts"
-    },
-    "./plugins/repository/module-augmentation/*/": {
-      "types": "./dist/types/plugins/repository/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/repository/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/repository/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/repository/module-augmentation/index.ts"
     },
     "./plugins/repository/module-augmentation/*": {
       "types": "./dist/types/plugins/repository/module-augmentation/*",
@@ -1116,12 +996,6 @@
       "require": "./dist/cjs/plugins/repository/resolution/*.cjs",
       "default": "./src/plugins/repository/resolution/*.ts"
     },
-    "./plugins/repository/resolution/*/": {
-      "types": "./dist/types/plugins/repository/resolution/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/repository/resolution/index.mjs",
-      "require": "./dist/cjs/plugins/repository/resolution/*/index.cjs",
-      "default": "./src/*/plugins/repository/resolution/index.ts"
-    },
     "./plugins/repository/resolution/*": {
       "types": "./dist/types/plugins/repository/resolution/*",
       "import": "./dist/esm/plugins/repository/resolution/*",
@@ -1167,12 +1041,6 @@
       "import": "./dist/esm/plugins/repository/root-path-finder/*.mjs",
       "require": "./dist/cjs/plugins/repository/root-path-finder/*.cjs",
       "default": "./src/plugins/repository/root-path-finder/*.ts"
-    },
-    "./plugins/repository/root-path-finder/*/": {
-      "types": "./dist/types/plugins/repository/root-path-finder/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/repository/root-path-finder/index.mjs",
-      "require": "./dist/cjs/plugins/repository/root-path-finder/*/index.cjs",
-      "default": "./src/*/plugins/repository/root-path-finder/index.ts"
     },
     "./plugins/repository/root-path-finder/*": {
       "types": "./dist/types/plugins/repository/root-path-finder/*",
@@ -1220,12 +1088,6 @@
       "require": "./dist/cjs/plugins/workspace/module-augmentation/*.cjs",
       "default": "./src/plugins/workspace/module-augmentation/*.ts"
     },
-    "./plugins/workspace/module-augmentation/*/": {
-      "types": "./dist/types/plugins/workspace/module-augmentation/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/workspace/module-augmentation/index.mjs",
-      "require": "./dist/cjs/plugins/workspace/module-augmentation/*/index.cjs",
-      "default": "./src/*/plugins/workspace/module-augmentation/index.ts"
-    },
     "./plugins/workspace/module-augmentation/*": {
       "types": "./dist/types/plugins/workspace/module-augmentation/*",
       "import": "./dist/esm/plugins/workspace/module-augmentation/*",
@@ -1271,12 +1133,6 @@
       "import": "./dist/esm/plugins/workspace/registry-resolution/*.mjs",
       "require": "./dist/cjs/plugins/workspace/registry-resolution/*.cjs",
       "default": "./src/plugins/workspace/registry-resolution/*.ts"
-    },
-    "./plugins/workspace/registry-resolution/*/": {
-      "types": "./dist/types/plugins/workspace/registry-resolution/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/workspace/registry-resolution/index.mjs",
-      "require": "./dist/cjs/plugins/workspace/registry-resolution/*/index.cjs",
-      "default": "./src/*/plugins/workspace/registry-resolution/index.ts"
     },
     "./plugins/workspace/registry-resolution/*": {
       "types": "./dist/types/plugins/workspace/registry-resolution/*",
@@ -1324,12 +1180,6 @@
       "require": "./dist/cjs/plugins/workspace/resolution/*.cjs",
       "default": "./src/plugins/workspace/resolution/*.ts"
     },
-    "./plugins/workspace/resolution/*/": {
-      "types": "./dist/types/plugins/workspace/resolution/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/workspace/resolution/index.mjs",
-      "require": "./dist/cjs/plugins/workspace/resolution/*/index.cjs",
-      "default": "./src/*/plugins/workspace/resolution/index.ts"
-    },
     "./plugins/workspace/resolution/*": {
       "types": "./dist/types/plugins/workspace/resolution/*",
       "import": "./dist/esm/plugins/workspace/resolution/*",
@@ -1375,12 +1225,6 @@
       "import": "./dist/esm/plugins/workspace/root-path-finder/*.mjs",
       "require": "./dist/cjs/plugins/workspace/root-path-finder/*.cjs",
       "default": "./src/plugins/workspace/root-path-finder/*.ts"
-    },
-    "./plugins/workspace/root-path-finder/*/": {
-      "types": "./dist/types/plugins/workspace/root-path-finder/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/workspace/root-path-finder/index.mjs",
-      "require": "./dist/cjs/plugins/workspace/root-path-finder/*/index.cjs",
-      "default": "./src/*/plugins/workspace/root-path-finder/index.ts"
     },
     "./plugins/workspace/root-path-finder/*": {
       "types": "./dist/types/plugins/workspace/root-path-finder/*",
@@ -1428,12 +1272,6 @@
       "require": "./dist/cjs/plugins/fs/*.cjs",
       "default": "./src/plugins/fs/*.ts"
     },
-    "./plugins/fs/*/": {
-      "types": "./dist/types/plugins/fs/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/fs/index.mjs",
-      "require": "./dist/cjs/plugins/fs/*/index.cjs",
-      "default": "./src/*/plugins/fs/index.ts"
-    },
     "./plugins/fs/*": {
       "types": "./dist/types/plugins/fs/*",
       "import": "./dist/esm/plugins/fs/*",
@@ -1479,12 +1317,6 @@
       "import": "./dist/esm/plugins/package/*.mjs",
       "require": "./dist/cjs/plugins/package/*.cjs",
       "default": "./src/plugins/package/*.ts"
-    },
-    "./plugins/package/*/": {
-      "types": "./dist/types/plugins/package/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/package/index.mjs",
-      "require": "./dist/cjs/plugins/package/*/index.cjs",
-      "default": "./src/*/plugins/package/index.ts"
     },
     "./plugins/package/*": {
       "types": "./dist/types/plugins/package/*",
@@ -1532,12 +1364,6 @@
       "require": "./dist/cjs/plugins/process/*.cjs",
       "default": "./src/plugins/process/*.ts"
     },
-    "./plugins/process/*/": {
-      "types": "./dist/types/plugins/process/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/process/index.mjs",
-      "require": "./dist/cjs/plugins/process/*/index.cjs",
-      "default": "./src/*/plugins/process/index.ts"
-    },
     "./plugins/process/*": {
       "types": "./dist/types/plugins/process/*",
       "import": "./dist/esm/plugins/process/*",
@@ -1583,12 +1409,6 @@
       "import": "./dist/esm/plugins/project/*.mjs",
       "require": "./dist/cjs/plugins/project/*.cjs",
       "default": "./src/plugins/project/*.ts"
-    },
-    "./plugins/project/*/": {
-      "types": "./dist/types/plugins/project/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/project/index.mjs",
-      "require": "./dist/cjs/plugins/project/*/index.cjs",
-      "default": "./src/*/plugins/project/index.ts"
     },
     "./plugins/project/*": {
       "types": "./dist/types/plugins/project/*",
@@ -1636,12 +1456,6 @@
       "require": "./dist/cjs/plugins/repository/*.cjs",
       "default": "./src/plugins/repository/*.ts"
     },
-    "./plugins/repository/*/": {
-      "types": "./dist/types/plugins/repository/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/repository/index.mjs",
-      "require": "./dist/cjs/plugins/repository/*/index.cjs",
-      "default": "./src/*/plugins/repository/index.ts"
-    },
     "./plugins/repository/*": {
       "types": "./dist/types/plugins/repository/*",
       "import": "./dist/esm/plugins/repository/*",
@@ -1687,12 +1501,6 @@
       "import": "./dist/esm/plugins/workspace/*.mjs",
       "require": "./dist/cjs/plugins/workspace/*.cjs",
       "default": "./src/plugins/workspace/*.ts"
-    },
-    "./plugins/workspace/*/": {
-      "types": "./dist/types/plugins/workspace/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/workspace/index.mjs",
-      "require": "./dist/cjs/plugins/workspace/*/index.cjs",
-      "default": "./src/*/plugins/workspace/index.ts"
     },
     "./plugins/workspace/*": {
       "types": "./dist/types/plugins/workspace/*",
@@ -1740,12 +1548,6 @@
       "require": "./dist/cjs/utils/fs/path-existence-checker/*.cjs",
       "default": "./src/utils/fs/path-existence-checker/*.ts"
     },
-    "./utils/fs/path-existence-checker/*/": {
-      "types": "./dist/types/utils/fs/path-existence-checker/*/index.d.ts",
-      "import": "./dist/esm/*/utils/fs/path-existence-checker/index.mjs",
-      "require": "./dist/cjs/utils/fs/path-existence-checker/*/index.cjs",
-      "default": "./src/*/utils/fs/path-existence-checker/index.ts"
-    },
     "./utils/fs/path-existence-checker/*": {
       "types": "./dist/types/utils/fs/path-existence-checker/*",
       "import": "./dist/esm/utils/fs/path-existence-checker/*",
@@ -1791,12 +1593,6 @@
       "import": "./dist/esm/utils/fs/root-path-finder/*.mjs",
       "require": "./dist/cjs/utils/fs/root-path-finder/*.cjs",
       "default": "./src/utils/fs/root-path-finder/*.ts"
-    },
-    "./utils/fs/root-path-finder/*/": {
-      "types": "./dist/types/utils/fs/root-path-finder/*/index.d.ts",
-      "import": "./dist/esm/*/utils/fs/root-path-finder/index.mjs",
-      "require": "./dist/cjs/utils/fs/root-path-finder/*/index.cjs",
-      "default": "./src/*/utils/fs/root-path-finder/index.ts"
     },
     "./utils/fs/root-path-finder/*": {
       "types": "./dist/types/utils/fs/root-path-finder/*",
@@ -1844,12 +1640,6 @@
       "require": "./dist/cjs/utils/process/cwd/*.cjs",
       "default": "./src/utils/process/cwd/*.ts"
     },
-    "./utils/process/cwd/*/": {
-      "types": "./dist/types/utils/process/cwd/*/index.d.ts",
-      "import": "./dist/esm/*/utils/process/cwd/index.mjs",
-      "require": "./dist/cjs/utils/process/cwd/*/index.cjs",
-      "default": "./src/*/utils/process/cwd/index.ts"
-    },
     "./utils/process/cwd/*": {
       "types": "./dist/types/utils/process/cwd/*",
       "import": "./dist/esm/utils/process/cwd/*",
@@ -1895,12 +1685,6 @@
       "import": "./dist/esm/utils/fs/*.mjs",
       "require": "./dist/cjs/utils/fs/*.cjs",
       "default": "./src/utils/fs/*.ts"
-    },
-    "./utils/fs/*/": {
-      "types": "./dist/types/utils/fs/*/index.d.ts",
-      "import": "./dist/esm/*/utils/fs/index.mjs",
-      "require": "./dist/cjs/utils/fs/*/index.cjs",
-      "default": "./src/*/utils/fs/index.ts"
     },
     "./utils/fs/*": {
       "types": "./dist/types/utils/fs/*",
@@ -1948,12 +1732,6 @@
       "require": "./dist/cjs/utils/path/*.cjs",
       "default": "./src/utils/path/*.ts"
     },
-    "./utils/path/*/": {
-      "types": "./dist/types/utils/path/*/index.d.ts",
-      "import": "./dist/esm/*/utils/path/index.mjs",
-      "require": "./dist/cjs/utils/path/*/index.cjs",
-      "default": "./src/*/utils/path/index.ts"
-    },
     "./utils/path/*": {
       "types": "./dist/types/utils/path/*",
       "import": "./dist/esm/utils/path/*",
@@ -1999,12 +1777,6 @@
       "import": "./dist/esm/utils/process/*.mjs",
       "require": "./dist/cjs/utils/process/*.cjs",
       "default": "./src/utils/process/*.ts"
-    },
-    "./utils/process/*/": {
-      "types": "./dist/types/utils/process/*/index.d.ts",
-      "import": "./dist/esm/*/utils/process/index.mjs",
-      "require": "./dist/cjs/utils/process/*/index.cjs",
-      "default": "./src/*/utils/process/index.ts"
     },
     "./utils/process/*": {
       "types": "./dist/types/utils/process/*",
@@ -2052,12 +1824,6 @@
       "require": "./dist/cjs/utils/promise/*.cjs",
       "default": "./src/utils/promise/*.ts"
     },
-    "./utils/promise/*/": {
-      "types": "./dist/types/utils/promise/*/index.d.ts",
-      "import": "./dist/esm/*/utils/promise/index.mjs",
-      "require": "./dist/cjs/utils/promise/*/index.cjs",
-      "default": "./src/*/utils/promise/index.ts"
-    },
     "./utils/promise/*": {
       "types": "./dist/types/utils/promise/*",
       "import": "./dist/esm/utils/promise/*",
@@ -2103,12 +1869,6 @@
       "import": "./dist/esm/bootstrap/*.mjs",
       "require": "./dist/cjs/bootstrap/*.cjs",
       "default": "./src/bootstrap/*.ts"
-    },
-    "./bootstrap/*/": {
-      "types": "./dist/types/bootstrap/*/index.d.ts",
-      "import": "./dist/esm/*/bootstrap/index.mjs",
-      "require": "./dist/cjs/bootstrap/*/index.cjs",
-      "default": "./src/*/bootstrap/index.ts"
     },
     "./bootstrap/*": {
       "types": "./dist/types/bootstrap/*",
@@ -2156,12 +1916,6 @@
       "require": "./dist/cjs/config/*.cjs",
       "default": "./src/config/*.ts"
     },
-    "./config/*/": {
-      "types": "./dist/types/config/*/index.d.ts",
-      "import": "./dist/esm/*/config/index.mjs",
-      "require": "./dist/cjs/config/*/index.cjs",
-      "default": "./src/*/config/index.ts"
-    },
     "./config/*": {
       "types": "./dist/types/config/*",
       "import": "./dist/esm/config/*",
@@ -2207,12 +1961,6 @@
       "import": "./dist/esm/context/*.mjs",
       "require": "./dist/cjs/context/*.cjs",
       "default": "./src/context/*.ts"
-    },
-    "./context/*/": {
-      "types": "./dist/types/context/*/index.d.ts",
-      "import": "./dist/esm/*/context/index.mjs",
-      "require": "./dist/cjs/context/*/index.cjs",
-      "default": "./src/*/context/index.ts"
     },
     "./context/*": {
       "types": "./dist/types/context/*",
@@ -2260,12 +2008,6 @@
       "require": "./dist/cjs/eventing/*.cjs",
       "default": "./src/eventing/*.ts"
     },
-    "./eventing/*/": {
-      "types": "./dist/types/eventing/*/index.d.ts",
-      "import": "./dist/esm/*/eventing/index.mjs",
-      "require": "./dist/cjs/eventing/*/index.cjs",
-      "default": "./src/*/eventing/index.ts"
-    },
     "./eventing/*": {
       "types": "./dist/types/eventing/*",
       "import": "./dist/esm/eventing/*",
@@ -2311,12 +2053,6 @@
       "import": "./dist/esm/extension/*.mjs",
       "require": "./dist/cjs/extension/*.cjs",
       "default": "./src/extension/*.ts"
-    },
-    "./extension/*/": {
-      "types": "./dist/types/extension/*/index.d.ts",
-      "import": "./dist/esm/*/extension/index.mjs",
-      "require": "./dist/cjs/extension/*/index.cjs",
-      "default": "./src/*/extension/index.ts"
     },
     "./extension/*": {
       "types": "./dist/types/extension/*",
@@ -2364,12 +2100,6 @@
       "require": "./dist/cjs/fs/*.cjs",
       "default": "./src/fs/*.ts"
     },
-    "./fs/*/": {
-      "types": "./dist/types/fs/*/index.d.ts",
-      "import": "./dist/esm/*/fs/index.mjs",
-      "require": "./dist/cjs/fs/*/index.cjs",
-      "default": "./src/*/fs/index.ts"
-    },
     "./fs/*": {
       "types": "./dist/types/fs/*",
       "import": "./dist/esm/fs/*",
@@ -2415,12 +2145,6 @@
       "import": "./dist/esm/hooks/*.mjs",
       "require": "./dist/cjs/hooks/*.cjs",
       "default": "./src/hooks/*.ts"
-    },
-    "./hooks/*/": {
-      "types": "./dist/types/hooks/*/index.d.ts",
-      "import": "./dist/esm/*/hooks/index.mjs",
-      "require": "./dist/cjs/hooks/*/index.cjs",
-      "default": "./src/*/hooks/index.ts"
     },
     "./hooks/*": {
       "types": "./dist/types/hooks/*",
@@ -2468,12 +2192,6 @@
       "require": "./dist/cjs/integration/*.cjs",
       "default": "./src/integration/*.ts"
     },
-    "./integration/*/": {
-      "types": "./dist/types/integration/*/index.d.ts",
-      "import": "./dist/esm/*/integration/index.mjs",
-      "require": "./dist/cjs/integration/*/index.cjs",
-      "default": "./src/*/integration/index.ts"
-    },
     "./integration/*": {
       "types": "./dist/types/integration/*",
       "import": "./dist/esm/integration/*",
@@ -2519,12 +2237,6 @@
       "import": "./dist/esm/module/*.mjs",
       "require": "./dist/cjs/module/*.cjs",
       "default": "./src/module/*.ts"
-    },
-    "./module/*/": {
-      "types": "./dist/types/module/*/index.d.ts",
-      "import": "./dist/esm/*/module/index.mjs",
-      "require": "./dist/cjs/module/*/index.cjs",
-      "default": "./src/*/module/index.ts"
     },
     "./module/*": {
       "types": "./dist/types/module/*",
@@ -2572,12 +2284,6 @@
       "require": "./dist/cjs/plugins/*.cjs",
       "default": "./src/plugins/*.ts"
     },
-    "./plugins/*/": {
-      "types": "./dist/types/plugins/*/index.d.ts",
-      "import": "./dist/esm/*/plugins/index.mjs",
-      "require": "./dist/cjs/plugins/*/index.cjs",
-      "default": "./src/*/plugins/index.ts"
-    },
     "./plugins/*": {
       "types": "./dist/types/plugins/*",
       "import": "./dist/esm/plugins/*",
@@ -2623,12 +2329,6 @@
       "import": "./dist/esm/utils/*.mjs",
       "require": "./dist/cjs/utils/*.cjs",
       "default": "./src/utils/*.ts"
-    },
-    "./utils/*/": {
-      "types": "./dist/types/utils/*/index.d.ts",
-      "import": "./dist/esm/*/utils/index.mjs",
-      "require": "./dist/cjs/utils/*/index.cjs",
-      "default": "./src/*/utils/index.ts"
     },
     "./utils/*": {
       "types": "./dist/types/utils/*",

--- a/packages/prelude/package.json
+++ b/packages/prelude/package.json
@@ -67,12 +67,6 @@
       "require": "./dist/cjs/config/*.cjs",
       "default": "./src/config/*.ts"
     },
-    "./config/*/": {
-      "types": "./dist/types/config/*/index.d.ts",
-      "import": "./dist/esm/*/config/index.mjs",
-      "require": "./dist/cjs/config/*/index.cjs",
-      "default": "./src/*/config/index.ts"
-    },
     "./config/*": {
       "types": "./dist/types/config/*",
       "import": "./dist/esm/config/*",
@@ -118,12 +112,6 @@
       "import": "./dist/esm/context/*.mjs",
       "require": "./dist/cjs/context/*.cjs",
       "default": "./src/context/*.ts"
-    },
-    "./context/*/": {
-      "types": "./dist/types/context/*/index.d.ts",
-      "import": "./dist/esm/*/context/index.mjs",
-      "require": "./dist/cjs/context/*/index.cjs",
-      "default": "./src/*/context/index.ts"
     },
     "./context/*": {
       "types": "./dist/types/context/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,9 +2048,14 @@ __metadata:
     globals: "npm:^16.0.0"
     typescript-eslint: "npm:^8.31.0"
   peerDependencies:
+    "@holypack/core": "*"
+    "@holypack/integration-typescript": "*"
     lodash.escaperegexp: "*"
     tapable: "*"
     typescript: "*"
+  peerDependenciesMeta:
+    "@holypack/integration-typescript":
+      optional: true
   languageName: node
   linkType: soft
 
@@ -2078,6 +2083,7 @@ __metadata:
     "@eslint/markdown": "npm:^6.4.0"
     "@holypack/core": "workspace:*"
     "@holypack/integration-babel": "workspace:*"
+    "@holypack/integration-typescript": "workspace:*"
     "@stylistic/eslint-plugin": "npm:^4.2.0"
     "@types/lodash.escaperegexp": "npm:^4"
     eslint: "npm:^9.25.1"
@@ -2094,9 +2100,14 @@ __metadata:
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.31.0"
   peerDependencies:
+    "@holypack/core": "*"
+    "@holypack/integration-typescript": "*"
     lodash.escaperegexp: "*"
     tapable: "*"
     typescript: "*"
+  peerDependenciesMeta:
+    "@holypack/integration-typescript":
+      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,7 +2042,7 @@ __metadata:
     eslint-plugin-import-x: "npm:^4.10.6"
     eslint-plugin-jsdoc: "npm:^50.6.10"
     eslint-plugin-n: "npm:^17.17.0"
-    eslint-plugin-perfectionist: "npm:^4.12.2"
+    eslint-plugin-perfectionist: "npm:^4.12.3"
     eslint-plugin-yml: "npm:^1.18.0"
     fast-glob: "npm:^3.3.3"
     globals: "npm:^16.0.0"
@@ -2085,7 +2085,7 @@ __metadata:
     eslint-plugin-import-x: "npm:^4.10.6"
     eslint-plugin-jsdoc: "npm:^50.6.10"
     eslint-plugin-n: "npm:^17.17.0"
-    eslint-plugin-perfectionist: "npm:^4.12.2"
+    eslint-plugin-perfectionist: "npm:^4.12.3"
     eslint-plugin-yml: "npm:^1.18.0"
     fast-glob: "npm:^3.3.3"
     globals: "npm:^16.0.0"
@@ -2126,7 +2126,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@holypack/internal-integration-node@workspace:internal/integrations/node"
   dependencies:
-    "@types/node": "npm:^22.14.1"
+    "@types/node": "npm:^22.15.2"
   languageName: unknown
   linkType: soft
 
@@ -2461,12 +2461,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.14.1":
-  version: 22.14.1
-  resolution: "@types/node@npm:22.14.1"
+"@types/node@npm:^22.15.2":
+  version: 22.15.2
+  resolution: "@types/node@npm:22.15.2"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/d49c4d00403b1c2348cf0701b505fd636d80aabe18102105998dc62fdd36dcaf911e73c7a868c48c21c1022b825c67b475b65b1222d84b704d8244d152bb7f86
+  checksum: 10c0/39da31d5fc63b14fabd217bb8a921c4a7fc3d99f233440209f9fc2d5d736e8773f7efc65223e2fd0e8db8390b0baab9c0cd2e951c2ece8b237f07313ab3cf295
   languageName: node
   linkType: hard
 
@@ -3499,16 +3499,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-perfectionist@npm:^4.12.2":
-  version: 4.12.2
-  resolution: "eslint-plugin-perfectionist@npm:4.12.2"
+"eslint-plugin-perfectionist@npm:^4.12.3":
+  version: 4.12.3
+  resolution: "eslint-plugin-perfectionist@npm:4.12.3"
   dependencies:
     "@typescript-eslint/types": "npm:^8.31.0"
     "@typescript-eslint/utils": "npm:^8.31.0"
     natural-orderby: "npm:^5.0.0"
   peerDependencies:
     eslint: ">=8.45.0"
-  checksum: 10c0/a89616bf6a69cb7817f32ac11d3e181c2a5e596507db7f4d27496c3d850cc53811293b4116eed3c86baf397866937ec8c67a57d8f61eb7903ede5b35b1a8ccf5
+  checksum: 10c0/c0fa2e79e575a8e2a1574c5404412d5e6d58c0151b5844a1db390e113e314b02d7572338e00eab9eec5f496d0f3153f9f94727c30684f7343023e3bc13e0f85c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,6 +1924,7 @@ __metadata:
   dependencies:
     "@holypack/eslint-plugin": "workspace:*"
     "@holypack/integration-eslint": "workspace:*"
+    "@holypack/integration-typescript": "workspace:*"
     holypack: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -2099,11 +2100,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@holypack/integration-typescript@portal:./integrations/typescript::locator=%40holypack%2F__monorepo__%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@holypack/integration-typescript@portal:./integrations/typescript::locator=%40holypack%2F__monorepo__%40workspace%3A."
+  dependencies:
+    typescript: "npm:^5.8.3"
+  peerDependencies:
+    "@holypack/core": "*"
+  languageName: node
+  linkType: soft
+
 "@holypack/integration-typescript@workspace:integrations/typescript":
   version: 0.0.0-use.local
   resolution: "@holypack/integration-typescript@workspace:integrations/typescript"
   dependencies:
+    "@holypack/core": "workspace:^"
+    "@holypack/integration-babel": "workspace:^"
     typescript: "npm:^5.8.3"
+  peerDependencies:
+    "@holypack/core": "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- [x] Support `.json` extension for automatic `exports` generation.
- [x] Make Babel copy JSON files during transpilation.
- [x] Create `TypeScriptIntegration` class.
- [x] Automatically find `tsconfig` root directory path.
- [x] Augment the context shared between integrations/plugins.
- [x] Complete todos waiting for TypeScript integration.